### PR TITLE
KP-8606 Allow downloading concordances on korp-dev

### DIFF
--- a/roles/korp-backend/files/korp_download/korp.cgi
+++ b/roles/korp-backend/files/korp_download/korp.cgi
@@ -537,7 +537,7 @@ def query(form):
         cqpextra["cut"] = form.get("cut")
 
     # Sort numbered CQP-queries numerically
-    cqp = [form.get(key).decode("utf-8") for key in sorted([k for k in form.keys() if k.startswith("cqp")], key=lambda x: int(x[3:]) if len(x) > 3 else 0)]
+    cqp = [form.get(key) for key in sorted([k for k in form.keys() if k.startswith("cqp")], key=lambda x: int(x[3:]) if len(x) > 3 else 0)]
 
     result = {}
 
@@ -736,10 +736,8 @@ def query(form):
         ("%d" % (statistics[c],) for c in sorted(corpora))
         if config.COMPACT_SAVED_STATS
         else ("%s:%d" % (c, h) for c, h in statistics.items()))
-    result["querydata"] = (
-        zlib.compress(
-            checksum + ";" + str(ns.total_hits) + ";" + querydata_corpora)
-        .encode("base64").replace("+", "-").replace("/", "_"))
+    data = checksum + ";" + str(ns.total_hits) + ";" + querydata_corpora
+    result["querydata"] = str(zlib.compress(data.encode("utf-8")))
     
     if use_cache:
         cachefilename = os.path.join(config.CACHE_DIR, "query_" + checksum)
@@ -3357,7 +3355,7 @@ def translate_undef(s):
 
 def get_hash(values):
     """Get a hash for a list of values."""
-    return str(zlib.crc32(";".join(x.encode("UTF-8") if isinstance(x, str) else str(x) for x in values)))
+    return str(zlib.crc32(";".join(str(x) for x in values).encode("utf-8")))
 
 
 class CQPError(Exception):

--- a/roles/korp-backend/files/korp_download/korp.cgi
+++ b/roles/korp-backend/files/korp_download/korp.cgi
@@ -24,7 +24,7 @@ import MySQLdb
 import zlib
 import urllib.request, urllib.parse, urllib.error
 import base64
-import md5
+from hashlib import md5
 from queue import Queue, Empty
 import threading
 import ast
@@ -176,7 +176,7 @@ def main():
     remote_user = cgi.os.environ.get('REMOTE_USER')
     if remote_user:
         auth_domain = remote_user.partition('@')[2]
-        auth_user = md5.new(remote_user).hexdigest()
+        auth_user = md5(remote_user.encode("utf-8")).hexdigest()
     else:
         auth_domain = auth_user = None
     logging.info('Auth-domain: %s', auth_domain)
@@ -3689,7 +3689,7 @@ def authenticate(_=None):
         postdata = {
             "username": user,
             "password": pw,
-            "checksum": md5.new(user + pw + config.AUTH_SECRET).hexdigest()
+            "checksum": md5((user + pw + config.AUTH_SECRET).encode("utf-8")).hexdigest()
         }
     else:
         return dict(username=None)

--- a/roles/korp-backend/files/korp_download/korp.cgi
+++ b/roles/korp-backend/files/korp_download/korp.cgi
@@ -20,7 +20,6 @@ import time
 import cgi
 import re
 import json
-import MySQLdb
 import zlib
 import urllib.request, urllib.parse, urllib.error
 import base64
@@ -29,10 +28,13 @@ from queue import Queue, Empty
 import threading
 import ast
 import itertools
-import MySQLdb.cursors
 import pickle
 import logging
 import korp_config as config
+
+import pymysql
+pymysql.install_as_MySQLdb()
+import MySQLdb
 
 ################################################################################
 # Nothing needs to be changed in this file. Use korp_config.py for configuration.

--- a/roles/korp-backend/files/korp_download/korp.cgi
+++ b/roles/korp-backend/files/korp_download/korp.cgi
@@ -129,7 +129,7 @@ def main():
      - debug: if set, return some extra information (for debugging)
     """
     starttime = time.time()
-    sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)  # Open unbuffered stdout
+    sys.stdout = os.fdopen(sys.stdout.fileno(), 'w')  # Open stdout
     print_header()
 
     if config.CACHE_DIR and not os.path.exists(config.CACHE_DIR):

--- a/roles/korp-backend/files/korp_download/korp_download.cgi
+++ b/roles/korp-backend/files/korp_download/korp_download.cgi
@@ -115,7 +115,7 @@ def main():
     # Decode \r\n as \n, since a bare \n in parameters seems to get
     # encoded as \r\n.
     form = dict((field,
-                 form_raw.getvalue(field).decode("utf-8").replace('\r\n', '\n'))
+                 form_raw.getvalue(field).replace('\r\n', '\n'))
                  for field in form_raw.keys())
     # Configure logging
     loglevel = logging.DEBUG if "debug" in form else LOG_LEVEL

--- a/roles/korp-backend/files/korp_download/korp_download.cgi
+++ b/roles/korp-backend/files/korp_download/korp_download.cgi
@@ -105,8 +105,8 @@ def main():
             return s[:maxlen - len(ellipsis) - 10] + ellipsis + s[-10:]
 
     starttime = time.time()
-    # Open unbuffered stdout
-    sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
+    # Open stdout
+    sys.stdout = os.fdopen(sys.stdout.fileno(), 'w')
     # Convert form fields to regular dictionary with unicode values;
     # assume that the input is encoded in UTF-8. Note that this does
     # not handle list values resulting form multiple occurrences of a

--- a/roles/korp-backend/files/korp_download/korp_download.cgi
+++ b/roles/korp-backend/files/korp_download/korp_download.cgi
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """
@@ -192,17 +192,17 @@ def print_header(obj):
             ``text/plain``, not an attachment.
     """
     charset = obj.get("download_charset")
-    print ("Content-Type: "
+    print("Content-Type: "
            + (obj.get("download_content_type", "text/plain")
               if "ERROR" not in obj
               else "text/plain")
            + (("; charset=" + charset) if charset else ""))
     if "ERROR" not in obj:
         # Default filename 
-        print make_content_disposition_attachment(
-            obj.get("download_filename", "korp_kwic"))
-        print "Content-Length: " + str(len(obj["download_content"]))
-    print
+        print(make_content_disposition_attachment(
+            obj.get("download_filename", "korp_kwic")))
+        print("Content-Length: " + str(len(obj["download_content"])))
+    print()
 
 
 def make_content_disposition_attachment(filename):
@@ -227,7 +227,7 @@ def make_content_disposition_attachment(filename):
 
     .. _Stackoverflow discussion: http://stackoverflow.com/questions/93551/how-to-encode-the-filename-parameter-of-content-disposition-header-in-http
     """
-    filename = urllib.quote(filename)
+    filename = urllib.parse.quote(filename)
     return (("Content-Disposition: attachment; "
              + ("filename*=UTF-8''{filename}; " if "%" in filename else "")
              + "filename={filename}")
@@ -243,12 +243,12 @@ def print_object(obj):
     """
     if "ERROR" in obj:
         error = obj["ERROR"]
-        print "Error when trying to download results:"
-        print error["type"] + ": " + error["value"]
+        print("Error when trying to download results:")
+        print(error["type"] + ": " + error["value"])
         if "traceback" in error:
-            print error["traceback"]
+            print(error["traceback"])
     else:
-        print obj["download_content"],
+        print(obj["download_content"], end=" ")
 
 
 if __name__ == "__main__":

--- a/roles/korp-backend/files/korp_download/korp_download.cgi
+++ b/roles/korp-backend/files/korp_download/korp_download.cgi
@@ -62,7 +62,7 @@ import cgi
 import logging
 import urllib
 import time
-import md5
+from hashlib import md5
 
 import korpexport.exporter as ke
 
@@ -145,7 +145,7 @@ def main():
     remote_user = cgi.os.environ.get('REMOTE_USER')
     if remote_user:
         logging.info('Auth-domain: %s', remote_user.partition('@')[2])
-        logging.info('Auth-user: %s', md5.new(remote_user).hexdigest())
+        logging.info('Auth-user: %s', md5(remote_user.encode('utf-8')).hexdigest())
     logging.debug('Env: %s', cgi.os.environ)
     try:
         result = ke.make_download_file(

--- a/roles/korp-backend/files/korp_download/korp_download.cgi
+++ b/roles/korp-backend/files/korp_download/korp_download.cgi
@@ -248,7 +248,8 @@ def print_object(obj):
         if "traceback" in error:
             print(error["traceback"])
     else:
-        print(obj["download_content"], end=" ")
+        sys.stdout.flush()
+        sys.stdout.buffer.write(obj["download_content"])
 
 
 if __name__ == "__main__":

--- a/roles/korp-backend/files/korp_download/korpexport/exporter.py
+++ b/roles/korp-backend/files/korp_download/korpexport/exporter.py
@@ -11,13 +11,13 @@ generate downloadable file contents.
 """
 
 
-from __future__ import absolute_import
+
 
 import os.path
 import time
 import pkgutil
 import json
-import urllib, urllib2
+import urllib.request, urllib.parse, urllib.error
 import re
 import logging
 
@@ -110,7 +110,7 @@ class KorpExporter(object):
     _FORMATTER_SUBPACKAGE = "format"
     """The `korpexport` subpackage containing actual formatter modules"""
 
-    _filename_format_default = u"korp_kwic_{cqpwords:.60}_{date}_{time}{ext}"
+    _filename_format_default = "korp_kwic_{cqpwords:.60}_{date}_{time}{ext}"
     """Default filename format"""
 
     _ENCODED_LIST_QUERY_PARAMS = [
@@ -182,7 +182,7 @@ class KorpExporter(object):
         result["download_charset"] = self._formatter.download_charset
         content = self._formatter.make_download_content(
             self._query_result, self._query_params, self._opts, **kwargs)
-        if isinstance(content, unicode) and self._formatter.download_charset:
+        if isinstance(content, str) and self._formatter.download_charset:
             content = content.encode(self._formatter.download_charset)
         result["download_content"] = content
         result["download_content_type"] = self._formatter.mime_type
@@ -241,7 +241,7 @@ class KorpExporter(object):
         concrete representation: for example, a token per line content
         format represented as comma-separated values.
         """
-        if isinstance(format_names, basestring):
+        if isinstance(format_names, str):
             format_names = re.split(r"[,;+\s]+", format_names)
         if len(format_names) == 1:
             return self._find_formatter_class(format_names[0])
@@ -409,13 +409,13 @@ class KorpExporter(object):
         # Encode the query parameters in UTF-8 for Korp server
         logging.debug("Korp server: %s", url_or_progname)
         logging.debug("Korp query params: %s", query_params)
-        query_params_encoded = urllib.urlencode(
+        query_params_encoded = urllib.parse.urlencode(
             dict((key, val.encode("utf-8"))
-                 for key, val in query_params.iteritems()))
+                 for key, val in list(query_params.items())))
         logging.debug("Encoded query params: %s", query_params_encoded)
         logging.debug("Env: %s", os.environ)
         if url_or_progname.startswith("http"):
-            return urllib2.urlopen(url_or_progname, query_params_encoded).read()
+            return urllib.request.urlopen(url_or_progname, query_params_encoded).read()
         else:
             env = {}
             # Pass the environment of this scropt appropriately
@@ -500,7 +500,7 @@ class KorpExporter(object):
 
         extract_show_opt("attrs", "show", "tokens")
         extract_show_opt("structs", "show_struct", "structs")
-        for opt_name, default_val in self._formatter.get_options().iteritems():
+        for opt_name, default_val in self._formatter.get_options().items():
             opts[opt_name] = self._form.get(opt_name, default_val)
         if self._form.get("korp_url"):
             opts["korp_url"] = self._form.get("korp_url")
@@ -547,7 +547,7 @@ class KorpExporter(object):
             self._corpus_config = json.loads(self._form["corpus_config"])
             self._corpus_info = dict(
                 [(corpname.lower(), config.get("info"))
-                 for corpname, config in self._corpus_config.iteritems()])
+                 for corpname, config in self._corpus_config.items()])
             self._add_corpus_info_from_config()
         self._retrieve_corpus_info_from_server(korp_server_url)
 
@@ -564,15 +564,15 @@ class KorpExporter(object):
             self._form["corpus_config_info_keys"].split(",")
             if "corpus_config_info_keys" in self._form
             else [])
-        for corpname, config in self._corpus_config.iteritems():
+        for corpname, config in self._corpus_config.items():
             corpname = corpname.lower()
-            for confkey, confval in config.iteritems():
+            for confkey, confval in config.items():
                 confkey = confkey.lower()
                 if (confkey in ["urn", "url"] or confkey.endswith("_urn")
                     or confkey.endswith("_url")):
                     self._add_corpus_info_item(corpname, confkey, confval)
                 elif confkey in config_info_items:
-                    for subkey, subval in confval.iteritems():
+                    for subkey, subval in confval.items():
                         self._add_corpus_info_item(
                             corpname, confkey + "_" + subkey, subval)
 
@@ -610,11 +610,10 @@ class KorpExporter(object):
         korp_corpus_info_json = self._query_korp_server(korp_server_url,
                                                         korp_info_params)
         korp_corpus_info = json.loads(korp_corpus_info_json)
-        for corpname, corpdata in (korp_corpus_info.get("corpora", {})
-                                   .iteritems()):
+        for corpname, corpdata in korp_corpus_info.get("corpora", {}).items():
             corpname = corpname.lower()
             corpinfo = corpdata.get("info", {})
-            for infoname, infoval in corpinfo.iteritems():
+            for infoname, infoval in corpinfo.items():
                 self._add_corpus_info_item(corpname, infoname, infoval)
 
     def _get_corpus_names(self):
@@ -686,4 +685,4 @@ class KorpExporter(object):
 # For testing: find formatter class for format "json".
 
 if __name__ == "__main__":
-    print KorpExporter._find_formatter_class('json')
+    print(KorpExporter._find_formatter_class('json'))

--- a/roles/korp-backend/files/korp_download/korpexport/exporter.py
+++ b/roles/korp-backend/files/korp_download/korpexport/exporter.py
@@ -182,8 +182,6 @@ class KorpExporter(object):
         result["download_charset"] = self._formatter.download_charset
         content = self._formatter.make_download_content(
             self._query_result, self._query_params, self._opts, **kwargs)
-        if isinstance(content, str) and self._formatter.download_charset:
-            content = content.encode(self._formatter.download_charset)
         result["download_content"] = content
         result["download_content_type"] = self._formatter.mime_type
         result["download_filename"] = self._get_filename()

--- a/roles/korp-backend/files/korp_download/korpexport/exporter.py
+++ b/roles/korp-backend/files/korp_download/korpexport/exporter.py
@@ -288,10 +288,10 @@ class KorpExporter(object):
         for _, module_name, _ in pkgutil.iter_modules([pkgpath]):
             try:
                 subpkg = __import__(
-                    self._FORMATTER_SUBPACKAGE + "." + module_name, globals())
+                    f"korpexport.format.{module_name}", globals())
             except ImportError as e:
                 continue
-            module = getattr(subpkg, module_name)
+            module = getattr(subpkg.format, module_name)
             for name in dir(module):
                 try:
                     module_class = getattr(module, name)

--- a/roles/korp-backend/files/korp_download/korpexport/exporter.py
+++ b/roles/korp-backend/files/korp_download/korpexport/exporter.py
@@ -440,7 +440,7 @@ class KorpExporter(object):
             output = p.communicate(query_params_url_encoded.encode("utf-8"))[0]
             logging.debug("Korp server output: %s", output)
             # Remove HTTP headers from the result
-            return re.sub(r"(?s)^.*?\n\n", "", output, count=1)
+            return re.sub(r"(?s)^.*?\n\n", "", output.decode("utf-8"), count=1)
 
     def _extract_options(self, korp_server_url=None):
         """Extract formatting options from form, affected by query params.

--- a/roles/korp-backend/files/korp_download/korpexport/exporter.py
+++ b/roles/korp-backend/files/korp_download/korpexport/exporter.py
@@ -182,6 +182,8 @@ class KorpExporter(object):
         result["download_charset"] = self._formatter.download_charset
         content = self._formatter.make_download_content(
             self._query_result, self._query_params, self._opts, **kwargs)
+        if isinstance(content, str):
+            content = content.encode("utf-8")
         result["download_content"] = content
         result["download_content_type"] = self._formatter.mime_type
         result["download_filename"] = self._get_filename()

--- a/roles/korp-backend/files/korp_download/korpexport/exporter.py
+++ b/roles/korp-backend/files/korp_download/korpexport/exporter.py
@@ -409,13 +409,13 @@ class KorpExporter(object):
         # Encode the query parameters in UTF-8 for Korp server
         logging.debug("Korp server: %s", url_or_progname)
         logging.debug("Korp query params: %s", query_params)
-        query_params_encoded = urllib.parse.urlencode(
+        query_params_url_encoded = urllib.parse.urlencode(
             dict((key, val.encode("utf-8"))
                  for key, val in list(query_params.items())))
-        logging.debug("Encoded query params: %s", query_params_encoded)
+        logging.debug("Encoded query params: %s", query_params_url_encoded)
         logging.debug("Env: %s", os.environ)
         if url_or_progname.startswith("http"):
-            return urllib.request.urlopen(url_or_progname, query_params_encoded).read()
+            return urllib.request.urlopen(url_or_progname, query_params_url_encoded).read()
         else:
             env = {}
             # Pass the environment of this scropt appropriately
@@ -434,10 +434,10 @@ class KorpExporter(object):
                  "REQUEST_METHOD": "POST",
                  "QUERY_STRING": "",
                  "CONTENT_TYPE": "application/x-www-form-urlencoded",
-                 "CONTENT_LENGTH": str(len(query_params_encoded))})
+                 "CONTENT_LENGTH": str(len(query_params_url_encoded))})
             logging.debug("Env modified: %s", env)
             p = Popen(url_or_progname, stdin=PIPE, stdout=PIPE, env=env)
-            output = p.communicate(query_params_encoded)[0]
+            output = p.communicate(query_params_url_encoded.encode("utf-8"))[0]
             logging.debug("Korp server output: %s", output)
             # Remove HTTP headers from the result
             return re.sub(r"(?s)^.*?\n\n", "", output, count=1)

--- a/roles/korp-backend/files/korp_download/korpexport/format/delimited.py
+++ b/roles/korp-backend/files/korp_download/korpexport/format/delimited.py
@@ -12,9 +12,6 @@ values).
 :Date: 2014
 """
 
-
-from __future__ import absolute_import
-
 import re
 
 import korpexport.queryresult as qr
@@ -48,9 +45,9 @@ class KorpExportFormatterDelimited(KorpExportFormatter):
     """
 
     _option_defaults = {
-        "infoitem_format": u"## {label}:{sp_or_nl}{value}",
-        "title_format": u"## {title}\n",
-        "param_format": u"##   {label}: {value}",
+        "infoitem_format": "## {label}:{sp_or_nl}{value}",
+        "title_format": "## {title}\n",
+        "param_format": "##   {label}: {value}",
         "param_sep": "\n",
         "sentence_fields": ("corpus,urn,metadata_link,licence_name,"
                             "licence_link,match_pos,left_context,match,"
@@ -107,8 +104,8 @@ class KorpExportFormatterDelimitedSentence(KorpExportFormatterDelimited):
     formats = ["sentence_line", "sentences", "fields_sentence"]
 
     _option_defaults = {
-        "content_format": u"{sentence_field_headings}{sentences}\n\n{info}",
-        "sentence_format": u"{fields}",
+        "content_format": "{sentence_field_headings}{sentences}\n\n{info}",
+        "sentence_format": "{fields}",
         "sentence_sep": "\n",
         "sentence_fields": ("corpus,?urn,?metadata_link,?licence_name,"
                             "?licence_link,match_pos,left_context,match,"
@@ -142,9 +139,9 @@ class KorpExportFormatterDelimitedSentence(KorpExportFormatterDelimited):
     _subformat_options = {
         "lemmas-resultinfo": {
             "show_info": "false",
-            "title_format": u"{title}",
-            "infoitem_format": u"{value}",
-            "param_format": u"{key}={value}",
+            "title_format": "{title}",
+            "infoitem_format": "{value}",
+            "param_format": "{key}={value}",
             "param_sep": "; ",
             "infoitems": "date,korp_url",
             "sentence_fields": ("hit_num,corpus,tokens,"
@@ -153,7 +150,7 @@ class KorpExportFormatterDelimitedSentence(KorpExportFormatterDelimited):
                                 "*structs,?urn,?metadata_link,?licence_name,"
                                 "date,hitcount,?korp_url,params"),
             "sentence_token_attrs": _lemmas_sentence_token_attrs,
-            "token_format": u"{match_open}{word}{match_close}",
+            "token_format": "{match_open}{word}{match_close}",
             "heading_rows": 1,
             # "match_open": u"<<<",
             # "match_close": u">>>",
@@ -239,7 +236,7 @@ class KorpExportFormatterDelimitedSentenceSimple(
             else:
                 match_format[opt_name] = ""
                 token_format = token_format.replace("{" + opt_name + "}", "")
-        mark_matches = any(match_format.itervalues())
+        mark_matches = any(match_format.values())
         # If token_format contains no match marking placeholders nor
         # any additional content, set token_format to None to speed up
         # token formatting in _format_sentence.
@@ -335,19 +332,19 @@ class KorpExportFormatterDelimitedSentenceSimple(
                     if token_format is not None:
                         # Sring replacing is faster than using
                         # string.format (called by self._format_item)
-                        token_str = token_format.replace(u"{word}", token_str)
+                        token_str = token_format.replace("{word}", token_str)
                         if match_open:
                             token_str = token_str.replace(
-                                u"{match_open}",
+                                "{match_open}",
                                 match_open if token_num == match_start else "")
                         if match_close:
                             token_str = token_str.replace(
-                                u"{match_close}",
+                                "{match_close}",
                                 (match_close if token_num == match_end - 1
                                  else ""))
                         if match_marker:
                             token_str = token_str.replace(
-                                u"{match_marker}",
+                                "{match_marker}",
                                 (match_marker
                                  if match_start <= token_num < match_end
                                  else ""))
@@ -369,7 +366,7 @@ class KorpExportFormatterDelimitedSentenceSimple(
             if callable(field_vals[fieldname]):
                 field_vals[fieldname] = field_vals[fieldname]()
         return self._opts["sentence_field_sep"].join(
-            unicode(field_vals[fieldname]) for fieldname in fieldnames)
+            str(field_vals[fieldname]) for fieldname in fieldnames)
 
 
 class KorpExportFormatterDelimitedToken(KorpExportFormatterDelimited):
@@ -393,29 +390,29 @@ class KorpExportFormatterDelimitedToken(KorpExportFormatterDelimited):
     formats = ["token_line", "tokens", "fields_token", "annotations", "annot"]
 
     _option_defaults = {
-        "content_format": u"{info}{token_field_headings}{sentences}",
-        "infoitems_format": u"{title}\n{infoitems}\n\n",
-        "field_headings_format": u"{field_headings}\n\n",
-        "sentence_format": u"{info}{fields}",
-        "sentence_info_format": (u"# {corpus}"
-                                 u" ({corpus_info}):"
-                                 u" sentence {sentence_id},"
-                                 u" position {match_pos};"
-                                 u" text attributes: {structs}\n"),
+        "content_format": "{info}{token_field_headings}{sentences}",
+        "infoitems_format": "{title}\n{infoitems}\n\n",
+        "field_headings_format": "{field_headings}\n\n",
+        "sentence_format": "{info}{fields}",
+        "sentence_info_format": ("# {corpus}"
+                                 " ({corpus_info}):"
+                                 " sentence {sentence_id},"
+                                 " position {match_pos};"
+                                 " text attributes: {structs}\n"),
         "sentence_fields": "left_context,match,right_context",
-        "sentence_field_format": u"{value}",
+        "sentence_field_format": "{value}",
         "sentence_field_sep": "",
         # Skip empty fields or fields containing only spaces
         "sentence_field_skip": r"\s*",
-        "corpus_info_format": (u"URN {urn};"
-                               u" licence {licence_name}: {licence_link};"
-                               u" metadata {metadata_link}"),
-        "token_format": u"{fields}\n",
-        "token_noattrs_format": u"{fields}\n",
+        "corpus_info_format": ("URN {urn};"
+                               " licence {licence_name}: {licence_link};"
+                               " metadata {metadata_link}"),
+        "token_format": "{fields}\n",
+        "token_noattrs_format": "{fields}\n",
         "token_sep": "",
         "token_fields": "word,*attrs",
         "token_field_sep": "\t",
-        "struct_format": u"{name}: {value}",
+        "struct_format": "{name}: {value}",
         "match_marker": "*",
         "match_field": "0"
         }
@@ -452,22 +449,22 @@ class KorpExportFormatterDelimitedReference(KorpExportFormatterDelimited):
     formats = ["reference", "biblio", "bibref", "ref"]
 
     _option_defaults = {
-        "content_format": u"{info}\n{sentences}",
-        "title_format": u"## {title}\n",
-        "infoitem_format": u"## {label}{sp_or_nl}{value}",
+        "content_format": "{info}\n{sentences}",
+        "title_format": "## {title}\n",
+        "infoitem_format": "## {label}{sp_or_nl}{value}",
         "infoitem_spacechar": "\t",
-        "param_format": u"##   {label}\t{value}",
-        "sentence_format": u"sentence\t{tokens}\n{corpus_info}\n{structs}\n",
+        "param_format": "##   {label}\t{value}",
+        "sentence_format": "sentence\t{tokens}\n{corpus_info}\n{structs}\n",
         "sentence_sep": "\n",
         "corpus_info_fields": (
             "corpus_name,urn,licence_name,licence_link,metadata_link"),
-        "corpus_info_field_format": u"{label}\t{value}",
+        "corpus_info_field_format": "{label}\t{value}",
         "corpus_info_field_sep": "\n",
-        "struct_format": u"{name}\t{value}",
+        "struct_format": "{name}\t{value}",
         "struct_sep": "\n",
-        "token_format": u"{match_open}{word}{match_close}",
-        "match_open": u"<<< ",
-        "match_close": u" >>>",
+        "token_format": "{match_open}{word}{match_close}",
+        "match_open": "<<< ",
+        "match_close": " >>>",
         "heading_cols": 1,
         }
 
@@ -495,9 +492,9 @@ class KorpExportFormatterCSV(KorpExportFormatterDelimited):
 
     _option_defaults = {
         "newline": "\r\n",
-        "delimiter": u",",
-        "quote": u"\"",
-        "replace_quote": u"\"\"",
+        "delimiter": ",",
+        "quote": "\"",
+        "replace_quote": "\"\"",
         }
 
     def __init__(self, **kwargs):
@@ -521,9 +518,9 @@ class KorpExportFormatterTSV(KorpExportFormatterDelimited):
     formats = ["tsv"]
 
     _option_defaults = {
-        "delimiter": u"\t",
-        "quote": u"",
-        "replace_quote": u""
+        "delimiter": "\t",
+        "quote": "",
+        "replace_quote": ""
         }
 
     def __init__(self, **kwargs):

--- a/roles/korp-backend/files/korp_download/korpexport/format/excel.py
+++ b/roles/korp-backend/files/korp_download/korpexport/format/excel.py
@@ -8,7 +8,7 @@ Format Korp query results as an Excel 97–2003 workbook (XLS).
 """
 
 
-import io as strio
+import io
 
 import xlwt
 
@@ -53,6 +53,6 @@ class KorpExportFormatterExcel(delimited.KorpExportFormatterDelimited):
             if row:
                 for colnum, value in enumerate(row.split("\t")):
                     worksheet.write(rownum, colnum, value)
-        output = strio.StringIO()
+        output = io.BytesIO()
         workbook.save(output)
         return output.getvalue()

--- a/roles/korp-backend/files/korp_download/korpexport/format/excel.py
+++ b/roles/korp-backend/files/korp_download/korpexport/format/excel.py
@@ -8,9 +8,7 @@ Format Korp query results as an Excel 97–2003 workbook (XLS).
 """
 
 
-from __future__ import absolute_import
-
-import cStringIO as strio
+import io as strio
 
 import xlwt
 

--- a/roles/korp-backend/files/korp_download/korpexport/format/html.py
+++ b/roles/korp-backend/files/korp_download/korpexport/format/html.py
@@ -7,9 +7,6 @@ Format Korp query results in HTML.
 :Date: 2016
 """
 
-
-from __future__ import absolute_import
-
 import re
 
 from xml.sax.saxutils import escape
@@ -77,20 +74,20 @@ class KorpExportFormatterHtml(KorpExportFormatter):
 
     _option_defaults = {
         "html_page_format": (
-            u"{doctype}\n<html>\n<head>\n{head}\n</head>\n"
-            u"<body>\n{body}</body>\n</html>\n"),
+            "{doctype}\n<html>\n<head>\n{head}\n</head>\n"
+            "<body>\n{body}</body>\n</html>\n"),
         "html_doctype_format": "<!DOCTYPE html>",
-        "html_head_format": (u"<meta charset=\"utf-8\"/>\n"
-                             u"<title>{title}</title>\n"
-                             u"<style>{style}</style>"),
-        "html_title_format": u"{title} {date}",
-        "html_style": u"",
-        "html_body_format": u"{heading}\n{korp_link}\n<hr/>\n{lines}",
-        "html_heading_format": u"<h1>{title} {date}</h1>",
+        "html_head_format": ("<meta charset=\"utf-8\"/>\n"
+                             "<title>{title}</title>\n"
+                             "<style>{style}</style>"),
+        "html_title_format": "{title} {date}",
+        "html_style": "",
+        "html_body_format": "{heading}\n{korp_link}\n<hr/>\n{lines}",
+        "html_heading_format": "<h1>{title} {date}</h1>",
         "html_korp_link_format": (
-            u"<p><a href=\"{korp_url}\" target=\"_blank\">{korp_url}</a></p>"),
-        "html_line_format": u"<p>{line}</p>\n",
-        "html_match_format": u"<strong>{match}</strong>",
+            "<p><a href=\"{korp_url}\" target=\"_blank\">{korp_url}</a></p>"),
+        "html_line_format": "<p>{line}</p>\n",
+        "html_match_format": "<strong>{match}</strong>",
     }
 
     def __init__(self, **kwargs):
@@ -104,7 +101,7 @@ class KorpExportFormatterHtml(KorpExportFormatter):
             and self._opts["html_match_format"]):
             self._match_re = re.compile(re.escape(self._match_open) + r"(.*?)"
                                         + re.escape(self._match_close))
-        for optname, optval in self._opts.iteritems():
+        for optname, optval in self._opts.items():
             if optname.startswith('html_') and optname.endswith('_format'):
                 self._opts[optname] = self._protect_html_tags(optval)
         self._skip_leading_lines = (self.get_option_int("skip_leading_lines")
@@ -198,12 +195,12 @@ class KorpExportFormatterHtmlTable(KorpExportFormatterHtml):
     formats = ["html-table", "html_table"]
 
     _option_defaults = {
-        "html_style": u"th { text-align: left; }",
+        "html_style": "th { text-align: left; }",
         "html_body_format": (
-            u"{heading}\n{korp_link}\n<hr/>\n<table>\n{lines}</table>\n"),
-        "html_line_format": u"<tr>{line}</tr>\n",
-        "html_heading_cell_format": u"<th>{cell}</th>",
-        "html_data_cell_format": u"<td>{cell}</td>",
+            "{heading}\n{korp_link}\n<hr/>\n<table>\n{lines}</table>\n"),
+        "html_line_format": "<tr>{line}</tr>\n",
+        "html_heading_cell_format": "<th>{cell}</th>",
+        "html_data_cell_format": "<td>{cell}</td>",
     }
 
     def __init__(self, **kwargs):

--- a/roles/korp-backend/files/korp_download/korpexport/format/json.py
+++ b/roles/korp-backend/files/korp_download/korpexport/format/json.py
@@ -7,9 +7,6 @@ Format Korp query results in JSON.
 :Date: 2014
 """
 
-
-from __future__ import absolute_import
-
 import json
 
 import korpexport.queryresult as qr

--- a/roles/korp-backend/files/korp_download/korpexport/format/nooj.py
+++ b/roles/korp-backend/files/korp_download/korpexport/format/nooj.py
@@ -23,8 +23,6 @@ NooJ should now display annotation if you tick the "Show text
 annotation structure" box. 
 """
 
-from __future__ import absolute_import
-
 import re
 import korpexport.queryresult as qr
 from korpexport.formatter import KorpExportFormatter
@@ -55,21 +53,21 @@ class KorpExportFormatterNooJ(KorpExportFormatter):
     """
 
     _option_defaults = {
-        "content_format": u"{sentences}\n\n<!--\n{info}\n-->",
-        "infoitem_format": u"## {label}:{sp_or_nl}{value}",
+        "content_format": "{sentences}\n\n<!--\n{info}\n-->",
+        "infoitem_format": "## {label}:{sp_or_nl}{value}",
         "title_format": "## {title} \n",
-        "param_format": u"## {label}: {value}",
+        "param_format": "## {label}: {value}",
         "param_sep": "\n",
-        "sentence_format": u"<S>{tokens}</S>",
+        "sentence_format": "<S>{tokens}</S>",
         "sentence_sep": "\n\n",
         "sentence_fields": ("tokens"),
         "sentence_field_sep": " ",
-        "token_format": u'<LU LEMMA="{lemma}" '\
-                        u'CAT="{nooj_attrs}"{nooj_dep}>{word}</LU>',
-        "attr_sep": u" ",
-        "delimiter": u",",
-        "quote": u"\"",
-        "replace_quote": u"\"",
+        "token_format": '<LU LEMMA="{lemma}" '\
+                        'CAT="{nooj_attrs}"{nooj_dep}>{word}</LU>',
+        "attr_sep": " ",
+        "delimiter": ",",
+        "quote": "\"",
+        "replace_quote": "\"",
         }
 
     def __init__(self, *args, **kwargs):
@@ -117,10 +115,10 @@ class KorpExportFormatterNooJ(KorpExportFormatter):
                 dep_lemmas.update({item['ref']: item[lemma_key]})
     
         # rename " and , to overcome NooJ XML-restrictions
-        rename_dict = {'"': u'QUOTE',
-                       ',': u'COMMA',
-                       '<': u'A_BRACKET_LEFT',
-                       '>': u'A_BRACKET_RIGHT'}
+        rename_dict = {'"': 'QUOTE',
+                       ',': 'COMMA',
+                       '<': 'A_BRACKET_LEFT',
+                       '>': 'A_BRACKET_RIGHT'}
 
         if lemma_key and token[lemma_key] in rename_dict.keys():
             token[lemma_key] = rename_dict[token[lemma_key]]
@@ -135,8 +133,8 @@ class KorpExportFormatterNooJ(KorpExportFormatter):
             token['word'] = brackets[token['word']]
         
         if token['msd']:
-            token['msd'] = re.sub('<', u'\u02C2', token['msd'])
-            token['msd'] = re.sub('>', u'\u02C3', token['msd'])
+            token['msd'] = re.sub('<', u'\\u02C2', token['msd'])
+            token['msd'] = re.sub('>', u'\\u02C3', token['msd'])
         '''
         # remove POS if found also in MSD, add default NooJ category
         # marker for unknowns (UNK)
@@ -156,7 +154,7 @@ class KorpExportFormatterNooJ(KorpExportFormatter):
             token["msd"] = ""
 
         # format POS and MSD to NooJ standard
-        nooj_attrs = re.sub("\+$", "", u"{pos}+{msd}".format(
+        nooj_attrs = re.sub("\+$", "", "{pos}+{msd}".format(
             pos=token["pos"].upper(),
             msd=token["msd"].lower()))
 
@@ -165,14 +163,14 @@ class KorpExportFormatterNooJ(KorpExportFormatter):
             if token["dephead"] == "0":
                 dep_lemma = token[lemma_key]
                 token["dephead"] = token["ref"]
-            elif token["dephead"] in dep_lemmas.keys():
+            elif token["dephead"] in list(dep_lemmas.keys()):
                 dep_lemma = dep_lemmas[token["dephead"]]
             elif token["dephead"] == "_":
                 dep_lemma = "phrase"
             else:
                 dep_lemma = "[   ]"
 
-            nooj_dep = u' ID="{ref}" DEP="{deprel}+{dep_lemma}" ID_REF="{dephead}"'.format(
+            nooj_dep = ' ID="{ref}" DEP="{deprel}+{dep_lemma}" ID_REF="{dephead}"'.format(
                 ref=token["ref"],
                 deprel=token["deprel"].upper(),
                 dep_lemma=dep_lemma,
@@ -201,9 +199,9 @@ class KorpExportFormatterNooJ(KorpExportFormatter):
         # Allow direct format references to attr names
         format_args.update(dict(self._get_token_attrs(token)))
         format_args.update(kwargs)
-        format_args.update({u"nooj_attrs": nooj_attrs})
-        format_args.update({u"nooj_dep": nooj_dep})
-        if lemma_key: format_args.update({u"lemma": token[lemma_key]})
+        format_args.update({"nooj_attrs": nooj_attrs})
+        format_args.update({"nooj_dep": nooj_dep})
+        if lemma_key: format_args.update({"lemma": token[lemma_key]})
         result = self._format_item(
             format_name,
             fields=self._format_list("token_field",

--- a/roles/korp-backend/files/korp_download/korpexport/format/text.py
+++ b/roles/korp-backend/files/korp_download/korpexport/format/text.py
@@ -7,9 +7,6 @@ Format Korp query results in plain text formats.
 :Date: 2014
 """
 
-
-from __future__ import absolute_import
-
 from korpexport.formatter import KorpExportFormatter
 
 
@@ -35,13 +32,13 @@ class KorpExportFormatterText(KorpExportFormatter):
     # methods are as inherited from :class:`KorpExportFormatter`.
 
     _option_defaults = {
-        "content_format": u"{info}{sentences}",
-        "infoitems_format": u"{title}\n{infoitems}\n\n",
-        "infoitem_format": u"## {label}:{sp_or_nl}{value}",
-        "title_format": u"## {title}\n",
-        "param_format": u"##   {label}: {value}",
+        "content_format": "{info}{sentences}",
+        "infoitems_format": "{title}\n{infoitems}\n\n",
+        "infoitem_format": "## {label}:{sp_or_nl}{value}",
+        "title_format": "## {title}\n",
+        "param_format": "##   {label}: {value}",
         "param_sep": "\n",
-        "sentence_format": (u"{corpus} [{match_pos}]: {tokens} || {structs}\n"),
+        "sentence_format": ("{corpus} [{match_pos}]: {tokens} || {structs}\n"),
         "struct_sep": " | ",
         "match_open": "<<< ",
         "match_close": " >>>",
@@ -51,12 +48,12 @@ class KorpExportFormatterText(KorpExportFormatter):
         # Bare sentences without annotations or metadata, sentence per
         # line; the fist line contains title, timestamp and Korp URL
         "sentences-bare": {
-            "infoitems_format": u"{title} | {infoitems}\n",
-            "infoitem_format": u"{value}",
+            "infoitems_format": "{title} | {infoitems}\n",
+            "infoitem_format": "{value}",
             "infoitems" : "date,korp_url",
             "infoitem_sep" : " | ",
-            "title_format": u"{title}",
-            "sentence_format": u"{tokens}\n",
+            "title_format": "{title}",
+            "sentence_format": "{tokens}\n",
             "skip_leading_lines": "1",
         },
     }

--- a/roles/korp-backend/files/korp_download/korpexport/format/vrt.py
+++ b/roles/korp-backend/files/korp_download/korpexport/format/vrt.py
@@ -7,9 +7,6 @@ Format Korp query results in the VeRticalized Text (VRT) format of CWB.
 :Date: 2014
 """
 
-
-from __future__ import absolute_import
-
 from korpexport.formatter import KorpExportFormatter
 
 
@@ -39,27 +36,27 @@ class KorpExportFormatterVRT(KorpExportFormatter):
     structured_format = True
 
     _option_defaults = {
-        "content_format": (u"{info}{token_field_headings}"
-                           u"<korp_kwic>\n{sentences}</korp_kwic>\n"),
-        "infoitem_format": u"<!-- {label}:{sp_or_nl}{value} -->",
-        "title_format": u"<!-- {title} -->\n",
-        "param_format": u"       {label}: {value}",
+        "content_format": ("{info}{token_field_headings}"
+                           "<korp_kwic>\n{sentences}</korp_kwic>\n"),
+        "infoitem_format": "<!-- {label}:{sp_or_nl}{value} -->",
+        "title_format": "<!-- {title} -->\n",
+        "param_format": "       {label}: {value}",
         "param_sep": "\n",
-        "field_headings_format": u"<!-- Fields: {field_headings} -->\n",
+        "field_headings_format": "<!-- Fields: {field_headings} -->\n",
         # FIXME: This adds MATCH tags before any opening tags and
         # aftore any closing tags in match. It might require a
         # customized _format_sentence to get it right.
-        "sentence_format": (u"{left_context}<MATCH position=\"{match_pos}\">\n"
-                            u"{match}</MATCH>\n{right_context}"),
-        "token_format": u"{structs_open}{fields}\n{structs_close}",
+        "sentence_format": ("{left_context}<MATCH position=\"{match_pos}\">\n"
+                            "{match}</MATCH>\n{right_context}"),
+        "token_format": "{structs_open}{fields}\n{structs_close}",
         "token_sep": "",
         "token_field_sep": "\t",
-        "attr_sep": u"\t",
-        "token_struct_open_noattrs_format": u"<{name}>\n",
-        "token_struct_open_attrs_format": u"<{name} {attrs}>\n",
-        "token_struct_close_format": u"</{name}>\n",
-        "token_struct_attr_format": u"{name}=\"{value}\"",
-        "token_struct_attr_sep": u" ",
+        "attr_sep": "\t",
+        "token_struct_open_noattrs_format": "<{name}>\n",
+        "token_struct_open_attrs_format": "<{name} {attrs}>\n",
+        "token_struct_close_format": "</{name}>\n",
+        "token_struct_attr_format": "{name}=\"{value}\"",
+        "token_struct_attr_sep": " ",
         "combine_token_structs": "True",
         "xml_declaration": "False"
         }
@@ -71,7 +68,7 @@ class KorpExportFormatterVRT(KorpExportFormatter):
         super(KorpExportFormatterVRT, self)._adjust_opts()
         if self.get_option_bool("xml_declaration"):
             self._opts["content_format"] = (
-                u'<?xml version="1.0" encoding="UTF-8" standalone="yes” ?>\n'
+                '<?xml version="1.0" encoding="UTF-8" standalone="yes” ?>\n'
                 + self._opts["content_format"])
 
     # FIXME: Close open tags if the struct attribute value for a

--- a/roles/korp-backend/files/korp_download/korpexport/formatter.py
+++ b/roles/korp-backend/files/korp_download/korpexport/formatter.py
@@ -13,7 +13,7 @@ information.
 """
 
 
-from __future__ import absolute_import
+
 
 import time
 import string
@@ -297,7 +297,7 @@ class KorpExportFormatter(object):
         "newline": "\n",
         "show_info": "True",
         "show_field_headings": "True",
-        "content_format": u"{info}{sentence_field_headings}{sentences}",
+        "content_format": "{info}{sentence_field_headings}{sentences}",
         "infoitems_format": "{title}{infoitems}\n",
         "infoitems": "date,korp_url,params,hitcount",
         "infoitem_labels": {
@@ -307,13 +307,13 @@ class KorpExportFormatter(object):
             "korp_url": "Korp URL",
             "korp_server_url": "Korp server URL"
             },
-        "infoitem_format": u"{label}:{sp_or_nl}{value}",
+        "infoitem_format": "{label}:{sp_or_nl}{value}",
         "infoitem_sep": "\n",
-        "title_format": u"{title}\n",
+        "title_format": "{title}\n",
         "title": "Korp search results",
         "date_format": "%Y-%m-%d %H:%M:%S",
-        "hitcount_format": u"{hitcount}",
-        "params_format": u"{params}",
+        "hitcount_format": "{hitcount}",
+        "params_format": "{params}",
         "params": "corpus,cqp,defaultcontext,defaultwithin,sort,start,end",
         "param_labels": {
             "corpus": "corpora",
@@ -322,14 +322,14 @@ class KorpExportFormatter(object):
             "defaultwithin": "within",
             "sort": "sorting"
             },
-        "param_format": u"{label}: {value}",
+        "param_format": "{label}: {value}",
         "param_sep": "; ",
-        "field_headings_format": u"{field_headings}\n",
-        "sentence_format": (u"{info}: {left_context}"
-                            u"{match_open}{match}{match_close}"
-                            u"{right_context}\n"),
-        "sentence_sep": u"",
-        "sentence_info_format": u"{corpus} {match_pos}",
+        "field_headings_format": "{field_headings}\n",
+        "sentence_format": ("{info}: {left_context}"
+                            "{match_open}{match}{match_close}"
+                            "{right_context}\n"),
+        "sentence_sep": "",
+        "sentence_info_format": "{corpus} {match_pos}",
         "sentence_fields": "",
         "sentence_field_labels": {
             "match_pos": "match position",
@@ -351,10 +351,10 @@ class KorpExportFormatter(object):
             "originals": "original forms",
             "normalizeds": "normalized forms",
             },
-        "sentence_field_format": u"{value}",
+        "sentence_field_format": "{value}",
         "sentence_field_sep": "",
         "sentence_token_attrs": "",
-        "corpus_info_format": u"{fields}",
+        "corpus_info_format": "{fields}",
         "corpus_info_fields": "",
         "corpus_info_field_labels": {
             "corpus_name": "corpus",
@@ -363,34 +363,34 @@ class KorpExportFormatter(object):
             "licence_link": "licence link",
             "metadata_link": "metadata link",
             },
-        "corpus_info_field_format": u"{value}",
+        "corpus_info_field_format": "{value}",
         "corpus_info_field_sep": "",
-        "aligned_format": u"{sentence}",
-        "aligned_sep": u" | ",
-        "struct_format": u"{name}: {value}",
-        "struct_sep": u"; ",
-        "token_format": u"{match_open}{word}[{attrs}]{match_close}",
-        "token_noattrs_format": u"{match_open}{word}{match_close}",
-        "token_attr_format": u"{match_open}{attr}{match_close}",
-        "token_sep": u" ",
-        "word_format": u"{word}",
-        "attr_only_format": u"{value}",
+        "aligned_format": "{sentence}",
+        "aligned_sep": " | ",
+        "struct_format": "{name}: {value}",
+        "struct_sep": "; ",
+        "token_format": "{match_open}{word}[{attrs}]{match_close}",
+        "token_noattrs_format": "{match_open}{word}{match_close}",
+        "token_attr_format": "{match_open}{attr}{match_close}",
+        "token_sep": " ",
+        "word_format": "{word}",
+        "attr_only_format": "{value}",
         "token_fields": "word,*attrs",
         "token_field_labels": {
             "match_mark": "match"
             },
-        "token_field_format": u"{value}",
+        "token_field_format": "{value}",
         "token_field_sep": ";",
-        "attr_format": u"{value}",
-        "attr_sep": u";",
-        "token_struct_open_format": u"",
-        "token_struct_close_format": u"",
+        "attr_format": "{value}",
+        "attr_sep": ";",
+        "token_struct_open_format": "",
+        "token_struct_close_format": "",
         "token_struct_open_sep": "",
         "token_struct_close_sep": "",
         "combine_token_structs": "False",
-        "match_open": u"",
-        "match_close": u"",
-        "match_marker": u"*",
+        "match_open": "",
+        "match_close": "",
+        "match_marker": "*",
         }
     """Default values for options; subclasses can override individually."""
 
@@ -551,7 +551,7 @@ class KorpExportFormatter(object):
             if item in self._opts:
                 available_corpus_info.add(item)
         for optkey in self._opts.get("list_valued_opts", []):
-            if isinstance(self._opts.get(optkey), basestring):
+            if isinstance(self._opts.get(optkey), str):
                 if self._opts[optkey] == "":
                     self._opts[optkey] = []
                 else:
@@ -761,7 +761,7 @@ class KorpExportFormatter(object):
             key=key,
             label=lambda: self._opts[item_type + "_labels"].get(key, key),
             value=value,
-            sp_or_nl=lambda: "\n" if "\n" in unicode(value) else space,
+            sp_or_nl=lambda: "\n" if "\n" in str(value) else space,
             **format_args)
 
     def _format_field_headings(self, item_type, **kwargs):

--- a/roles/korp-backend/files/korp_download/korpexport/queryresult.py
+++ b/roles/korp-backend/files/korp_download/korpexport/queryresult.py
@@ -150,7 +150,7 @@ def get_sentence_corpus_link(sentence, itemname=None, urn_resolver=""):
 
 def get_sentence_tokens_base(sentence, start, end):
     """Get the tokens (list) of `sentence`, in the range [`start`:`end`]."""
-    if (start >= 0 or start is None) and (end >= 0 or end is None):
+    if (start is None or start >= 0) and (end is None or end >= 0):
         return sentence["tokens"][start:end]
     else:
         return []

--- a/roles/korp-backend/files/korp_download/korpexport/queryresult.py
+++ b/roles/korp-backend/files/korp_download/korpexport/queryresult.py
@@ -13,9 +13,6 @@ functions in this module.
 """
 
 
-from __future__ import absolute_import
-
-
 def get_sentences(query_result):
     """Get the sentences  contained in `query_result`."""
     return query_result.get("kwic", [])
@@ -79,8 +76,8 @@ def get_occurring_corpus_info(query_result):
     """Return the keys of ``corpus_info`` in `query_result` as a set."""
     result = set()
     for sentence in get_sentences(query_result):
-        for key, val in (sentence.get("corpus_info") or {}).iteritems():
-            if isinstance(val, basestring):
+        for key, val in (sentence.get("corpus_info") or {}).items():
+            if isinstance(val, str):
                 result.add(key)
             else:
                 for subval in val:
@@ -114,7 +111,7 @@ def get_sentence_corpus_info_item(sentence, item, subitem=None):
     info = sentence.get("corpus_info") or {}
     if item in info:
         if subitem is not None:
-            if not isinstance(info[item], basestring) and subitem in info[item]:
+            if not isinstance(info[item], str) and subitem in info[item]:
                 return info[item][subitem]
             else:
                 return ""
@@ -220,7 +217,7 @@ def get_aligned_sentences(sentence):
             alignment attribute, corresponding to the id of the
             aligned corpus. The list is sorted by the align key.
     """
-    return sorted(sentence.get("aligned", {}).iteritems())
+    return sorted(sentence.get("aligned", {}).items())
 
 
 def get_sentence_structs(sentence, structnames=None):
@@ -240,7 +237,7 @@ def get_sentence_structs(sentence, structnames=None):
     if sentence_structs is None:
         return []
     elif structnames is None:
-        return list(sentence_structs.iteritems())
+        return list(sentence_structs.items())
     else:
         # Value may be None; convert them to empty strings
         return [(structname, sentence_structs.get(structname) or "")
@@ -266,7 +263,7 @@ def get_token_attrs(token, attrnames=None):
             the attributes occurring in `token`
     """
     if attrnames is None:
-        return [(attrname, val) for attrname, val in token.iteritems()
+        return [(attrname, val) for attrname, val in token.items()
                 if attrname != "structs"]
     else:
         return [(attrname, token.get(attrname) or "") for attrname in attrnames]

--- a/roles/korp-backend/tasks/main.yml
+++ b/roles/korp-backend/tasks/main.yml
@@ -241,6 +241,15 @@
     group: apache
     mode: "640"
 
+- name: Configure CGI script location for Apache
+  ansible.builtin.lineinfile:
+    path: /etc/httpd/conf.d/cgi.conf
+    line: "ScriptAlias /korp/cgi-bin/ {{ korp_static_frontend_cgi_dir }}/"
+    state: present
+    create: true
+    mode: 0644
+  notify: restart korp-backend
+
 - name: configure logrotate for backend
   template:
     src: "korp_logrotate"


### PR DESCRIPTION
The cgi scripts and their dependencies have been converted to Python 3, mostly automatically using `2to3`. On top of this, bytes vs string discrepancies and such were adjusted manually until a functional end state was achieved. At this code will be obsolete in relatively near future ([KP-4950](https://jira.eduuni.fi/browse/KP-4950)), great care was not put into making everything tip-top.

Unbuffered `print` for strings is no longer an option: `sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)` would need to be `wb`. To both get all the data out in a timely manner and avoid doing big renovations, I ended up just making the opened stdout unbuffered (I guess that it no longer actually does anything significant, but I decided not to push my luck after everything seemed to work) and flushing it before we send the actual downloadable file (always as bytes using `sys.stdout.buffer.write`: otherwise the excel files don't seem to work as expected).

The results were tested by provisioning a dev instance of Korp on Pouta and populating it with the reittidemo dataset. Concordances for search https://www.kielipankki.fi/korp/#?corpus=reittidemo&cqp=%5Blemma%20%3D%20%22olla%22%5D&search_tab=1&search=cqp were downloaded in each available format both from the dev instance and from current production corp. The comparison between the two revealed no significant differences: apart from differing timestamps etc, the only differences were:
- in JSON the new version does not add trailing spaces (e.g. `"sentence",\n` instead of `"sentence", \n`)
- in NOOJ the CAT attribute order can differ between the old and new implementation (e.g. `CAT="N+subcat_prop+casechange_up+case_nom+num_sg+other_unk"` instead of `CAT="N+subcat_prop+other_unk+num_sg+case_nom+casechange_up"`)