### PR TITLE
KP-8637 Disable syncing large but unnecessary directories

### DIFF
--- a/roles/fetch_backup/templates/sync_korp_servers.j2
+++ b/roles/fetch_backup/templates/sync_korp_servers.j2
@@ -31,7 +31,12 @@ rsync -av --delete                      korp.csc.fi:/var/www/html/download /data
 ERROR_CODE=$(($ERROR_CODE+$?))
 
 # CWB data
-rsync -av --exclude korp/cache          korp.csc.fi:/mnt/cwbdata           /data1
+rsync -av \
+  --exclude korp/cache \
+  --exclude corpora/tmp \
+  --exclude corpora/vrt \
+  --exclude corpora/sql \
+  korp.csc.fi:/mnt/cwbdata /data1
 ERROR_CODE=$(($ERROR_CODE+$?))
 
 # Apache config


### PR DESCRIPTION
The corpora/vrt and corpora/sql directories hold files related to corpus preparation done in the old Korp but not necessary for serving users from korp2. Similarly, the data currently in corpora/tmp is sizeable but not relevant.

Technically, instead of excluding some directories, we could only include the necessary directories. This seemed like the smaller change though, and as we are doing things with time pressure, I felt that it's best to start with the smallest useful change. We can do the include-based logic with better time later.