### PR TITLE
KP-8467 Take weekly backups of Signbank data from Allas

### DIFF
--- a/roles/fetch_backup/defaults/main.yml
+++ b/roles/fetch_backup/defaults/main.yml
@@ -1,3 +1,5 @@
 backup_id_pub: "lb_passwords/backup/id_rsa.pub"
 backup_id_key: "lb_passwords/backup/id_rsa"
 anacron_hours: "8-9" # run cron-* after Pouta VMs.
+
+backup_venv: "/home/backup/.backup_venv"

--- a/roles/fetch_backup/tasks/main.yml
+++ b/roles/fetch_backup/tasks/main.yml
@@ -10,7 +10,6 @@
   pip:
     name: s5cmd
     virtualenv: "{{ backup_venv }}"
-    virtualenv_python: python3.8  # Temporary workaround for outdated korp2, remove for korp3
   become: true
   become_user: backup
 

--- a/roles/fetch_backup/tasks/main.yml
+++ b/roles/fetch_backup/tasks/main.yml
@@ -10,7 +10,6 @@
   pip:
     name: s5cmd
     virtualenv: "{{ backup_venv }}"
-    virtualenv_python: python3
   become: true
   become_user: backup
 

--- a/roles/fetch_backup/tasks/main.yml
+++ b/roles/fetch_backup/tasks/main.yml
@@ -6,13 +6,24 @@
    shell: /bin/bash
    groups: nobody
 
-- name: Create Backup Dir
+- name: Install s5cmd for backups
+  pip:
+    name: s5cmd
+    virtualenv: "{{ backup_venv }}"
+    virtualenv_python: python3
+  become: true
+  become_user: backup
+
+- name: Create backup directories
   file:
-   path: "{{ backup_dir }}"
+   path: "{{ item }}"
    state: directory
    owner: backup
    group: backup
    mode: 0770
+  loop:
+    - "{{ backup_dir }}"
+    - "{{ backup_dir }}/signbank"
 
 - name: Ensure .ssh
   file:
@@ -31,6 +42,16 @@
   loop:
    - get_pouta_webserver_vm_backup
    - sync_korp_servers
+
+- name: Set up weekly backups
+  template:
+   src: "{{ item }}.j2"
+   dest: "/etc/cron.weekly/{{ item }}"
+   owner: root
+   group: backup
+   mode: 0750
+  loop:
+   - get_signbank_backup
 
 - name: Setup SSH keys
   copy:

--- a/roles/fetch_backup/tasks/main.yml
+++ b/roles/fetch_backup/tasks/main.yml
@@ -10,6 +10,7 @@
   pip:
     name: s5cmd
     virtualenv: "{{ backup_venv }}"
+    virtualenv_python: python3.8  # Temporary workaround for outdated korp2, remove for korp3
   become: true
   become_user: backup
 

--- a/roles/fetch_backup/templates/get_signbank_backup.j2
+++ b/roles/fetch_backup/templates/get_signbank_backup.j2
@@ -22,7 +22,7 @@ if ! [ -d $BACKUP_DIR/ ]; then
   echo "Backup of Signbank failed."
   echo "Local backup directory \"$BACKUP_DIR\" does not exist."
 else
-  s5cmd --endpoint-url "https://a3s.fi" --no-sign-request sync s3://signbank_data/* $BACKUP_DIR
+  s5cmd --numworkers 8 --endpoint-url "https://a3s.fi" --no-sign-request sync s3://signbank_data/* $BACKUP_DIR
 fi # ! [ -d $BACKUP_DIR/ ]
 
 # mails error message and optionally log file

--- a/roles/fetch_backup/templates/get_signbank_backup.j2
+++ b/roles/fetch_backup/templates/get_signbank_backup.j2
@@ -23,6 +23,7 @@ if ! [ -d $BACKUP_DIR/ ]; then
   echo "Local backup directory \"$BACKUP_DIR\" does not exist."
 else
   s5cmd --numworkers 8 --endpoint-url "https://a3s.fi" --no-sign-request sync s3://signbank_data/* $BACKUP_DIR
+  EXIT_CODE=$?
 fi # ! [ -d $BACKUP_DIR/ ]
 
 # mails error message and optionally log file
@@ -43,6 +44,6 @@ if [ ! -e $LOG_MESSAGE_FILE ]; then
 fi
 
 # mail errors if the logfile is not empty
-if [ -s $LOG_MESSAGE_FILE ]; then
+if [ $EXIT_CODE -ne 0 ]; then
    mail_log "Error. See mail body for details" $LOG_MESSAGE_FILE
 fi

--- a/roles/fetch_backup/templates/get_signbank_backup.j2
+++ b/roles/fetch_backup/templates/get_signbank_backup.j2
@@ -22,7 +22,7 @@ if ! [ -d $BACKUP_DIR/ ]; then
   echo "Backup of Signbank failed."
   echo "Local backup directory \"$BACKUP_DIR\" does not exist."
 else
-  s5cmd --numworkers 8 --endpoint-url "https://a3s.fi" --no-sign-request sync s3://signbank_data/* $BACKUP_DIR
+  s5cmd --numworkers 8 --endpoint-url "https://a3s.fi" --no-sign-request --delete sync s3://signbank_data/* $BACKUP_DIR
   EXIT_CODE=$?
 fi # ! [ -d $BACKUP_DIR/ ]
 

--- a/roles/fetch_backup/templates/get_signbank_backup.j2
+++ b/roles/fetch_backup/templates/get_signbank_backup.j2
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# restart as user backup (from root)
+if [ "$(id -u)" -eq 0 ]; then
+    exec sudo -H -u backup $0 "$@"
+fi
+
+source {{ backup_venv }}/bin/activate
+
+BACKUP_DIR="{{ backup_dir }}/signbank"
+LOG_MESSAGE_FILE=/tmp/get_signbank_backup.txt
+
+# remove possible last log file
+rm -f $LOG_MESSAGE_FILE
+
+# stderr to stdout:
+exec > $LOG_MESSAGE_FILE
+exec 2>&1
+
+
+if ! [ -d $BACKUP_DIR/ ]; then
+  echo "Backup of Signbank failed."
+  echo "Local backup directory \"$BACKUP_DIR\" does not exist."
+else
+  s5cmd --endpoint-url "https://a3s.fi" --no-sign-request sync s3://signbank_data/* $BACKUP_DIR
+fi # ! [ -d $BACKUP_DIR/ ]
+
+# mails error message and optionally log file
+# $1: Error message
+# $2: Path to file
+mail_log() {
+RECIPIENT=root # Use .forward to forward root's mail if needed.
+   if [ -n $2 ]; then # mail the file content
+       cat $2 | mail -s "$0 @ `hostname -f`: $1" $RECIPIENT
+   else
+       echo "(No mail content)"  | mail -s "$0 @ `hostname -f`: $1"  $RECIPIENT
+   fi
+}
+
+# mail error if logfile does not exist
+if [ ! -e $LOG_MESSAGE_FILE ]; then
+   mail_log "No logfile!" "In normal operation, an empty logfile should have been created."
+fi
+
+# mail errors if the logfile is not empty
+if [ -s $LOG_MESSAGE_FILE ]; then
+   mail_log "Error. See mail body for details" $LOG_MESSAGE_FILE
+fi


### PR DESCRIPTION
The backups are created using s5cmd tool, which allows copying public buckets without setting AWS secrets (unlike s3cmd, which refuses to do anything without the configuration file). The s5cmd tool is not standard issue CSC best practice, but it seems relatively reliable: it is developed by a company, last release is less than a year old and there is activity in PRs and issues (latest merges less than a month ago).

Unlike other backups, these are not compressed: the data is mostly already-compressed video, and what isn't video is jpegs and such. I did a small test with 4.1 GB of the data and that compressed to 4.0 GB when doing `tar -zcf`.

The backup script boilerplate with mails etc is very similar to the other backup scripts.

TODO:
- [x] Merge https://github.com/CSCfi/Kielipankki-korp-ansible/pull/29 first: this is on top of it
- [x] Merge https://github.com/CSCfi/Kielipankki-korp-ansible/pull/30 first: this is on top of it