### PR TITLE
KP-8793 Disable metashare backups

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -38,7 +38,6 @@ intermediate_chain: GEANT_OV_RSA_CA4.pem
 backup_dir: "/var/backup"
 #Server IPs for getting backups:
 portal_server_ip: 195.148.21.204
-metashare_server_ip: 86.50.170.142
 webanno_server_ip: 195.148.31.151
 
 # access control from proxy

--- a/roles/fetch_backup/templates/get_pouta_webserver_vm_backup.j2
+++ b/roles/fetch_backup/templates/get_pouta_webserver_vm_backup.j2
@@ -8,7 +8,7 @@ fi
 # backs up lamp/tomcat servers, (e.g. portal, metashare, webanno, specified by $SERVER_IPS) using $BACKUP_GLOB to $LOCAL_BACKUP_DIR
 
 # One way to get IPs: openstack server list|egrep "webanno|portal|metashare"|cut -f 5 -d"|"|cut -f3 -d " "
-SERVER_IPS="{{ portal_server_ip }} {{ metashare_server_ip }} {{ webanno_server_ip}}"
+SERVER_IPS="{{ portal_server_ip }} {{ webanno_server_ip}}"
 
 # on Korp2:
 LOCAL_BACKUP_DIR="/var/backup"

--- a/roles/fetch_backup/templates/get_pouta_webserver_vm_backup.j2
+++ b/roles/fetch_backup/templates/get_pouta_webserver_vm_backup.j2
@@ -5,9 +5,9 @@ if [ "$(id -u)" -eq 0 ]; then
     exec sudo -H -u backup $0 "$@"
 fi
 
-# backs up lamp/tomcat servers, (e.g. portal, metashare, webanno, specified by $SERVER_IPS) using $BACKUP_GLOB to $LOCAL_BACKUP_DIR
+# backs up lamp/tomcat servers, (e.g. portal, webanno, specified by $SERVER_IPS) using $BACKUP_GLOB to $LOCAL_BACKUP_DIR
 
-# One way to get IPs: openstack server list|egrep "webanno|portal|metashare"|cut -f 5 -d"|"|cut -f3 -d " "
+# One way to get IPs: openstack server list|egrep "webanno|portal"|cut -f 5 -d"|"|cut -f3 -d " "
 SERVER_IPS="{{ portal_server_ip }} {{ webanno_server_ip}}"
 
 # on Korp2:

--- a/roles/fetch_backup/templates/get_pouta_webserver_vm_backup.j2
+++ b/roles/fetch_backup/templates/get_pouta_webserver_vm_backup.j2
@@ -34,7 +34,7 @@ else
       SERVER_NAME=`ssh backup@$IP hostname`
 
       NEWEST_BACKUP=`ssh backup@$IP "ls -rt $BACKUP_GLOB |tail -n 1"`
-      BACKUP_FILE=`basename $NEWEST_BACKUP` 
+      BACKUP_FILE=`basename $NEWEST_BACKUP`
       LOCAL_BACKUP_FILE=$LOCAL_BACKUP_DIR/$BACKUP_FILE
 
       if [ -f $LOCAL_BACKUP_FILE ]; then


### PR DESCRIPTION
We no longer use META-SHARE for metadata, so the machine has been shut down and will no longer need backing up.