### PR TITLE
Kp 8713 korp3 test

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -9,6 +9,10 @@ local_user: "{{ lookup('env','USER') }}"
 # name Pouta dev instance using local user to avoid conflicts.
 vm_name_postfix: "{{ local_user }}"
 
+#Allow access from Korp2
+sg_custom_ssh_ips:
+  - "86.50.31.6/32"  #Korp2
+
 korp_backend_name: Kielipankki-korp-backend
 korp_backend_socket: "/run/{{ korp_backend_name }}.sock"
 

--- a/inventories/korp3
+++ b/inventories/korp3
@@ -1,0 +1,1 @@
+korp ansible_host=korp3.csc.fi

--- a/korp-production.yml
+++ b/korp-production.yml
@@ -1,5 +1,8 @@
 ---
 
+- name: Preprocessing unique to production instance
+  ansible.builtin.import_playbook: production-preprocess.yml
+
 - name: Install Korp software
   ansible.builtin.import_playbook: korp-software.yml
 

--- a/pouta-vm.yml
+++ b/pouta-vm.yml
@@ -32,27 +32,12 @@
         allowed_ips:
           - "193.167.254.68/32" #opsview
 
-      - name: nagios
-        protocol: tcp
-        port: 5666
-        allowed_ips:
-          - "193.167.254.68/32" #opsview
-
       - name: http
         protocol: tcp
         port: 80
         allowed_ips:
           - "192.168.1.0/24" # pouta local network
 
-      - name: ssh
-        protocol: tcp
-        port: 22
-        allowed_ips:
-          - "193.166.1.0/24" #CSC Office
-          - "193.166.2.0/24" #CSC Office
-          - "193.166.84.0/24" #CSC VPN
-          - "193.166.85.0/24" #CSC VPN
-          - "86.50.31.6/32"  #Korp2
     authorized_users:
       - ktegel
       - ajarven

--- a/production-preprocess.yml
+++ b/production-preprocess.yml
@@ -1,0 +1,16 @@
+---
+
+- name: Production-only provisioning steps for Korp
+  hosts: korp
+  become: true
+
+  tasks:
+    - name: Disable SELinux
+      selinux:
+        policy: targeted
+        state: disabled
+      register: sestatus
+
+    - name: Restart server if needed
+      reboot:
+      when: sestatus.changed|default(false)

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,5 +4,5 @@ roles:
 collections:
   - name: git@github.com:CSCfi/Kielipankki-ansible-common.git
     type: git
-    version: main
+    version: KP-8706_PaloAltoVPN
   - name: community.mysql

--- a/roles/firewall/templates/firewall.local.j2
+++ b/roles/firewall/templates/firewall.local.j2
@@ -2,9 +2,14 @@
 
 # Load new rules by running /etc/rc.d/rc{{ item }}.firewall
 
-# set rules
+# CSC Espoo and Cisco VPN, PaloAltoVPN
+iptables -I INPUT -m tcp -p tcp -s 193.166.1.0/24,193.166.2.0/24,193.166.84.0/24,193.166.85.0/24,193.166.83.192/28 --dport 22 -j ACCEPT -m comment --comment "Allow SSH"
+
+# rules for HTTP(S)
 ip{{ item }}tables -I INPUT -p tcp -m tcp --dport 443 -m comment --comment "Allow https from everywhere" -j ACCEPT
 ip{{ item }}tables -I INPUT -p tcp -m tcp --dport 80 -m comment --comment "Allow http from everywhere" -j ACCEPT
+
+# rules for Nagios
 ip{{ item }}tables -I INPUT -p tcp -m tcp -s 193.167.254.68 --dport 5666 -m comment --comment "Allow nagios" -j ACCEPT
 
 # set policies

--- a/roles/korp-backend/defaults/main.yml
+++ b/roles/korp-backend/defaults/main.yml
@@ -4,7 +4,7 @@ korp_backend_name: Kielipankki-korp-backend
 korp_backend_repo: https://github.com/CSCfi/{{ korp_backend_name }}.git
 korp_backend_version: master
 korp_backend_socket: "/run/{{ korp_backend_name }}.sock"
-cwb_svn_repo: http://svn.code.sf.net/p/cwb/code/cwb/trunk
+cwb_svn_repo: https://svn.code.sf.net/p/cwb/code/cwb/trunk
 cwb_revision: "r1732"
 cwb_registry: /v/corpora/registry
 cwb_compile_root: /v/appl/cwb

--- a/roles/korp-backend/tasks/main.yml
+++ b/roles/korp-backend/tasks/main.yml
@@ -1,28 +1,22 @@
 ---
 # Setup korp backend
 
-- name: install CentOS IUS release package
-  yum:
-    name: "https://repo.ius.io/ius-release-el{{ ansible_distribution_major_version }}.rpm"
-    state: present
-  when: ansible_distribution == 'CentOS'
-
 - name: Set timezone
   community.general.timezone:
     name: "{{ timezone }}"
 
 - name: Add gunicorn user
-  user:
+  ansible.builtin.user:
     name: gunicorn
     state: present
 
 - name: "add clarin group"
-  group:
+  ansible.builtin.group:
     name: clarin
     state: present
 
 - name: Install CWB compile environment
-  yum:
+  ansible.builtin.dnf:
     name:
       - subversion
       - make
@@ -37,7 +31,7 @@
     state: present
 
 - name: Install korp backend packages
-  yum:
+  ansible.builtin.dnf:
     name:
       - git
       - python3
@@ -52,7 +46,7 @@
       - python-xlwt # for korp_download.cgi
 
 - name: Create directories
-  file:
+  ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
     mode: "{{ item.mode }}"
@@ -61,7 +55,7 @@
   loop: "{{ mk_directories }}"
 
 - name: symlink /v/korp to /data1/korp
-  file:
+  ansible.builtin.file:
     src: /data1/korp
     dest: /v/korp
     owner: root
@@ -69,24 +63,26 @@
     state: link
 
 - name: Clone backend
-  git:
+  ansible.builtin.git:
     repo: "{{ korp_backend_repo  }}"
     version: "{{ korp_backend_version }}"
     dest: "{{ korp_backend_home }}"
+    umask: "0022"
 
 - name: Clone CWB subversion
-  subversion:
+  ansible.builtin.subversion:
     repo: "{{ cwb_svn_repo }}"
     dest: "{{ cwb_compile_root }}"
     revision: "{{ cwb_revision }}"
 
 - name: Copy cwb site config
-  template:
+  ansible.builtin.template:
     src: cwb_korp
     dest: "{{ cwb_compile_root }}/config/site/cwb_korp"
+    mode: "0644"
 
 - name: Compile/Install cwb
-  make:
+  community.general.make:
     chdir: "{{ cwb_compile_root }}"
     target: "{{ item }}"
     params:
@@ -100,21 +96,23 @@
   become: true
 
 - name: Install pip
-  pip:
+  ansible.builtin.pip:
     name: pip
     state: latest
     virtualenv: "{{ korp_backend_venv }}"
     virtualenv_python: python3
+    umask: "0022"
 
 - name: Install requirements
-  pip:
+  ansible.builtin.pip:
     requirements: "{{ korp_backend_home }}/requirements.txt"
     virtualenv: "{{ korp_backend_venv }}"
     virtualenv_python: python3
+    umask: "0022"
 
 - name: checkout worktrees
-  shell:
-    cmd: "git worktree add -f {{ item }}"
+  ansible.builtin.shell:
+    cmd: "umask 0022 && git worktree add -f {{ item }}"
     chdir: "{{ korp_backend_home }}"
     creates: "{{ item.split(' ')[0] }}/.git"
   loop:
@@ -122,8 +120,8 @@
     - "{{ korp_backend_plugin_home }} plugins/{{ korp_backend_version }}"
 
 - name: remove local changes in worktrees
-  shell:
-    cmd: "git checkout -f && git pull"
+  ansible.builtin.shell:
+    cmd: "umask 0022 && git checkout -f && git pull"
     chdir: "{{ item }}"
   loop:
     - "{{ korp_backend_auth_home }}"
@@ -133,10 +131,11 @@
     - restart korp-authserver
 
 - name: Enable default configs for some plugins
-  file:
+  ansible.builtin.file:
     src: "{{ korp_backend_plugin_home }}/korpplugins/{{ item }}/config.py.template"
     dest: "{{ korp_backend_plugin_home }}/korpplugins/{{ item }}/config.py"
     state: link
+    mode: "0644"
   loop:
     - charcoder
     - contenthider
@@ -145,9 +144,10 @@
     - restart korp-backend
 
 - name: Install custom configs for other plugins
-  template:
+  ansible.builtin.template:
     src: "{{ item }}_plugin_config.py"
     dest: "{{ korp_backend_plugin_home }}/korpplugins/{{ item }}/config.py"
+    mode: "0644"
   loop:
     - logger
     - protectedcorporadb
@@ -155,35 +155,39 @@
     - restart korp-backend
 
 - name: Install backend config
-  template:
+  ansible.builtin.template:
     src: backend_config.py
     dest: "{{ korp_backend_home }}/config.py"
+    mode: "0644"
   notify:
     - restart korp-backend
 
 - name: Install auth server config
-  template:
+  ansible.builtin.template:
     src: authserver_config.py
     dest: "{{ korp_backend_auth_home }}/auth/config.py"
+    mode: "0644"
   notify:
     - restart korp-authserver
 
 - name: Install latest gevent
-  pip:
+  ansible.builtin.pip:
     name: gevent
     state: latest
     virtualenv: "{{ korp_backend_venv }}"
     virtualenv_python: python3
+    umask: "0022"
   notify:
     - restart korp-backend
     - restart korp-authserver
 
 - name: Install gunicorn / start backend
-  pip:
+  ansible.builtin.pip:
     name: gunicorn
     state: latest
     virtualenv: "{{ korp_backend_venv }}"
     virtualenv_python: python3
+    umask: "0022"
   notify:
     - restart korp-backend
     - restart korp-authserver
@@ -194,6 +198,7 @@
     dest: "/etc/systemd/system/{{ item }}"
     owner: root
     group: root
+    mode: "0640"
   loop:
     - korp-backend.socket
     - korp-backend.service
@@ -216,7 +221,7 @@
     dest: "/etc/cron.daily/"
     owner: root
     group: root
-    mode: "755"
+    mode: "0755"
   loop:
     - clear_korp_cache
 
@@ -226,7 +231,7 @@
     dest: "{{ korp_backend_cgibin_dir }}"
     owner: root
     group: apache
-    mode: "755"
+    mode: "0755"
 
 - name: Precompile python files
   ansible.builtin.shell:
@@ -239,7 +244,7 @@
     dest: "{{ korp_backend_cgibin_dir }}/korp_config.py"
     owner: root
     group: apache
-    mode: "640"
+    mode: "0640"
 
 - name: Configure CGI script location for Apache
   ansible.builtin.lineinfile:
@@ -247,10 +252,10 @@
     line: "ScriptAlias /korp/cgi-bin/ {{ korp_static_frontend_cgi_dir }}/"
     state: present
     create: true
-    mode: 0644
+    mode: "0644"
   notify: restart korp-backend
 
 - name: configure logrotate for backend
-  template:
+  ansible.builtin.template:
     src: "korp_logrotate"
     dest: "/etc/logrotate.d/korp"

--- a/roles/korp-frontend/tasks/main.yml
+++ b/roles/korp-frontend/tasks/main.yml
@@ -2,7 +2,7 @@
 # Setup korp frontend
 
 - name: Add yarn repository
-  yum_repository:
+  ansible.builtin.yum_repository:
     name: yarn
     description: Yarn YUM repo
     baseurl: https://dl.yarnpkg.com/rpm/
@@ -10,18 +10,12 @@
     gpgkey: https://dl.yarnpkg.com/rpm/pubkey.gpg
 
 - name: Add nodejs repository
-  shell:
+  ansible.builtin.shell:
     cmd: curl -sL https://rpm.nodesource.com/setup_12.x | bash -
     creates: /etc/yum.repos.d/nodesource-el7.repo
 
-- name: install CentOS IUS release package
-  yum:
-    name: "https://repo.ius.io/ius-release-el{{ ansible_distribution_major_version }}.rpm"
-    state: present
-  when: ansible_distribution == 'CentOS'
-
 - name: Install basics
-  yum:
+  ansible.builtin.dnf:
     name:
       - nodejs
       - yarn
@@ -35,7 +29,7 @@
     cmd: npm install yarn
 
 - name: Ensure directories
-  file:
+  ansible.builtin.file:
     path: "{{ item }}"
     state: directory
     mode: 0755
@@ -46,23 +40,24 @@
     - "{{ korp_frontend_annlab_dir }}"
 
 - name: Clone frontend
-  git:
+  ansible.builtin.git:
     repo: "{{ korp_frontend_repo  }}"
     version: "{{ korp_frontend_version }}"
     dest: "{{ korp_frontend_home }}"
     force: true
+    umask: "0022"
   register: frontend_clone
 
 - name: Set compile_frontend
   # Request recompilation (compile_frontend = true) if an actual change has
   # happened, not if a local change has been overwritten, but nothing else
   # changed.
-  set_fact:
+  ansible.builtin.set_fact:
     compile_frontend: "{{ ( frontend_clone.after != frontend_clone.before ) or ( force_compile | default(false) ) }}"
 
 - name: checkout worktrees
-  shell:
-    cmd: "git worktree add -f {{ item }}"
+  ansible.builtin.shell:
+    cmd: "umask 0022 && git worktree add -f {{ item }}"
     chdir: "{{ korp_frontend_home }}"
     creates: "{{ item.split(' ')[0] }}/.git"
   loop:
@@ -71,7 +66,7 @@
     - "{{ korp_frontend_news_home }} news/{{ korp_frontend_version }}"
 
 - name: update worktrees
-  shell:
+  ansible.builtin.shell:
     cmd: "git pull"
     chdir: "{{ item }}"
   register: worktree
@@ -81,39 +76,41 @@
     - "{{ korp_frontend_news_home }}"
 
 - name: Skip this if all up to date
-  set_fact:
+  ansible.builtin.set_fact:
     compile_frontend: true
   when: (item.stdout != "Already up to date.") or ( force_compile | default(false))
   loop: "{{ worktree.results }}"
 
 - name: Install run_config
-  template:
+  ansible.builtin.template:
     src: run_config.json.j2
     dest: "{{ korp_frontend_home }}/run_config.json"
+    mode: "0644"
 
 - name: Install dependencies for frontend
   ansible.builtin.command:
-    cmd: yarn install
+    cmd: "umask 0022 && yarn install"
     chdir: "{{ korp_frontend_home }}"
   when: compile_frontend == true
 
 - name: Build frontend
-  shell:
-    cmd: yarn build
+  ansible.builtin.shell:
+    cmd: "umask 0022 && yarn build"
     chdir: "{{ korp_frontend_home }}"
   when: compile_frontend == true
 
 - name: Create news directories
-  file:
+  ansible.builtin.file:
     dest: "{{ item }}"
     state: directory
+    mode: "0755"
   loop:
     - "{{ korp_frontend_news_home }}/json"
     - "{{ korp_frontend_home }}/dist/news"
 
 - name: Compile News
-  shell:
-    cmd: "./compile.bash"
+  ansible.builtin.shell:
+    cmd: "umask 0022 && ./compile.bash"
     chdir: "{{ korp_frontend_news_home }}"
   when: compile_frontend == true
 


### PR DESCRIPTION
The goal was to setup korp3.csc.fi using Ansible. Frontend and backend do work, but korp3 is not yet whitelisted with kielipankkidb9, so db-related functionaliy (like login) does not work yet. I did test the proper propagation of Shibboleth attributes from the proxy. Other changes:
- making commands explicit (e.g file: > ansible.builtin.file:)
- fixing firewall settings (ssh port now controlled there! This should go to "common" at some point)
- "outsourcing" pouta fw settings to "common"
- setting umask: overriding the RHEL9 restrictive default