### PR TITLE
KP-9031 Install korp auth db administration script

### DIFF
--- a/roles/korp-backend/files/create-new-korp-authdb-DANGER-ERASES-EXISTING.sql
+++ b/roles/korp-backend/files/create-new-korp-authdb-DANGER-ERASES-EXISTING.sql
@@ -1,0 +1,34 @@
+/* Source this as and in mysql -u korp korp_auth. Except don't if
+   korp_auth has valuable content already. By Jussi Piitulainen,
+   jpiitula@ling.helsinki.fi, for FIN-CLARIN, Dec 2013. */
+
+drop table if exists auth_academic;
+drop table if exists auth_allow;
+drop table if exists auth_secret;
+drop table if exists auth_license;
+
+/* HTTP Basic Authentication username -
+   should rather be an EPPN */
+create table auth_academic(person varchar(80) not null,
+                           primary key (person));
+
+/* CWB name */
+/* PUB, ACA, RES */
+create table auth_license(corpus varchar(80) not null,
+			  license char(3) not null,
+                          primary key (corpus));
+
+/* Personal access to a corpus -
+   needed for RES, can have for ACA (or even PUB ;)
+   corpus must be known in this authorization service,
+   person need not (might be REMOTE_USER of Shibboleth) */
+create table auth_allow(person varchar(80) not null,
+                        corpus varchar(80) not null,
+                        primary key (person, corpus),
+			constraint foreign key (corpus)
+				   references auth_license(corpus));
+
+/* In the clear! */
+create table auth_secret(person varchar(80) not null,
+       	     		 secret varchar(240) not null,
+                         primary key (person));

--- a/roles/korp-backend/files/korp-authdb.py
+++ b/roles/korp-backend/files/korp-authdb.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # -*- mode: Python; -*-
 
 # A simple authentication and authorization database management tool

--- a/roles/korp-backend/files/korp-authdb.py
+++ b/roles/korp-backend/files/korp-authdb.py
@@ -1,0 +1,413 @@
+# -*- mode: Python; -*-
+
+# A simple authentication and authorization database management tool
+# to support Korp configuration with CLARIN access classes; to go with
+# an auth.cgi in backend/korp/.
+# By Jussi Piitulainen, jpiitula@ling.helsinki.fi, for
+# FIN-CLARIN, December 2013.
+# Updated for Python3 by Sam Hardwick, September 2024.
+
+
+import MySQLdb
+import sys, codecs, re
+
+import korp_authdb_config as auth_config
+
+
+class ArgumentError(Exception):
+    """Exception raised on invalid arguments"""
+
+    pass
+
+
+def usage_command(cursor, command, args):
+    print(
+        """\
+Usage: {prog} command [arg ...]
+
+The arguments in the command descriptions below are as follows:
+  PERSON: the Shibboleth (Haka) user name (username@domain)
+  CORPUS: the Korp corpus id (Corpus Workbench name of a corpus)
+  URN@LBR: the LBR id of the corpus: the corpus URN suffixed with "@LBR"
+
+Korp corpus ids are upper-cased and LBR ids are prefixed with
+"urn:nbn:fi:lb-" and suffixed with "@LBR" if they are missing.
+
+Available commands and their arguments:
+
+  PUB CORPUS ...        make corpora PUB
+  ACA CORPUS ...        make corpora ACA
+  RES CORPUS ...        make corpora RES
+    Note: ACA and RES corpora also need appropriate settings in the Korp
+    frontend corpus configuration.
+
+  lbr_register URN@LBR CORPUS ...
+                        map LBR id to Korp corpus ids
+  lbr_unregister URN@LBR CORPUS ...
+                        unmap LBR id and Korp corpus ids
+  lbr_map               show LBR id mappings
+
+  persons               list persons
+  corpora               list corpora and their licenses
+
+  allow PERSON [PERSON ... --] CORPUS ...
+                        give persons personal access to corpora
+  deny PERSON [PERSON ... --] CORPUS ...
+                        take away from persons personal access to corpora
+    Note: If you specify multiple PERSONs, the CORPUS ids need to be
+    separated from them by a double dash "--".
+
+DEPRECATED, DO NOT USE:
+  remove PERSON ...     remove persons (idempotent)
+    """.format(
+            prog=sys.argv[0]
+        )
+    )
+
+
+def remove_command(cursor, command, args):
+    """Remove person"""
+    (person,) = args
+    cursor.execute(
+        """
+    delete from auth_academic where person = %s""",
+        [person],
+    )
+    cursor.execute(
+        """
+    delete from auth_allow where person = %s""",
+        [person],
+    )
+    cursor.execute(
+        """
+    delete from auth_secret where person = %s""",
+        [person],
+    )
+
+
+def allow_command(cursor, command, args):
+    """Give person personal access to corpus"""
+    person, corpus = args
+    cursor.execute(
+        """
+    insert into auth_allow(person, corpus)
+    values (%s, %s)
+    on duplicate key
+    update corpus = corpus""",
+        [person, corpus],
+    )
+
+
+def deny_command(cursor, command, args):
+    """Take away personal access to corpus from person"""
+    person, corpus = args
+    cursor.execute(
+        """
+    delete from auth_allow
+    where person = %s and corpus = %s""",
+        [person, corpus],
+    )
+
+
+def lbr_register_command(cursor, command, args):
+    """Map a LBR URN ID to one or more (sub)coropra"""
+    lbr_id, corpus = args
+    cursor.execute(
+        """
+    insert into auth_lbr_map(lbr_id, corpus)
+    values (%s, %s)
+    on duplicate key
+    update corpus = corpus""",
+        [lbr_id, corpus],
+    )
+
+
+def lbr_unregister_command(cursoer, command, args):
+    """Map a LBR URN ID to one or more (sub)coropra"""
+    lbr_id, corpus = args
+    cursor.execute(
+        """
+    delete from auth_lbr_map
+    where lbr_id = %s and corpus = %s""",
+        [lbr_id, corpus],
+    )
+
+
+def license_command(cursor, command, args):
+    """Make corpus be of given type (PUB, ACA, or RES)"""
+    license = command
+    (corpus,) = args
+    cursor.execute(
+        """
+    insert into auth_license(corpus, license)
+    values (%s, %s)
+    on duplicate key
+    update license = %s""",
+        [corpus, license, license],
+    )
+    # Disabled because not currently working well
+    # check_config(corpus, license)
+
+
+def persons_command(cursor, command, args):
+    """List persons and their personally allowed corpora"""
+    cursor.execute(
+        """
+    (select distinct person from auth_allow)
+        order by person"""
+    )
+    for (person,) in cursor.fetchall():
+        print(person, end="")
+        cursor.execute(
+            """
+        select corpus from auth_allow
+        where person = %s
+        order by corpus""",
+            [person],
+        )
+        for corpus in cursor:
+            print(" ", corpus[0], end="")
+        print()
+
+
+def corpora_command(cursor, command, args):
+    """List corpora, their license (PUB, ACA, or RES), and their corporal
+    persons (persons allowed personal access to the corpus)"""
+    cursor.execute(
+        """
+    select corpus, license from auth_license
+    order by corpus"""
+    )
+    for corpus, license in cursor.fetchall():
+        print(corpus, license, end="")
+        cursor.execute(
+            """
+        select person from auth_allow
+        where corpus = %s
+        order by person""",
+            [corpus],
+        )
+        for (person,) in cursor:
+            print("", person, end="")
+        print()
+        # Disabled because not currently working well
+        # check_config(corpus, license)
+
+
+def lbr_map_command(cursor, command, args):
+    """List URN@LBR-IDs and Korp-ID mappings"""
+    cursor.execute(
+        """
+    select lbr_id, corpus from auth_lbr_map
+    order by lbr_id"""
+    )
+    for lbr_id, corpus in cursor.fetchall():
+        print("%s\t%s" % (lbr_id, corpus))
+
+
+def check_corpus_arg(corpus):
+    """Check a corpus argument and convert it to upper case"""
+    corpus = corpus.upper()
+    if not re.match(r"^[_A-Z][_A-Z0-9-]*$", corpus):
+        print('Warning: Invalid corpus id "{}"; skipping'.format(corpus))
+        return None
+    return corpus
+
+
+def check_lbr_id_arg(lbr_id):
+    """Check an LBR id argument and augment it if needed"""
+    # Note: This assumes that LBR ids are of the form
+    # "urn:nbn:fi:lb-NUMBER@LBR". If they are changed to something else, this
+    # will have to be modified accordingly.
+    if not re.match(r"^((urn:nbn:fi:)?lb-)?\d+(@LBR)?", lbr_id):
+        print('Warning: Invalid LBR id "{}"; skipping'.format(lbr_id))
+        return None
+    if not lbr_id.endswith("@LBR"):
+        lbr_id += "@LBR"
+    if not lbr_id.startswith("urn:"):
+        if not lbr_id.startswith("lb-"):
+            lbr_id = "lb-" + lbr_id
+        lbr_id = "urn:nbn:fi:" + lbr_id
+    return lbr_id
+
+
+def check_person_arg(person):
+    """Check a person (username) argument"""
+    if not re.match(r"^[a-zA-Z0-9_-]+@[a-zA-Z0-9_.-]+", person):
+        print('Warning: Possibly invalid username "{}"'.format(person))
+    return person
+
+
+# Values in dispatch are triples (command function, argument list split type,
+# argument types); see parse_arglist below for argument list split types.
+dispatch = dict(
+    remove=(remove_command, "+", "p"),
+    allow=(allow_command, "++", "pc"),
+    deny=(deny_command, "++", "pc"),
+    PUB=(license_command, "+", "c"),
+    ACA=(license_command, "+", "c"),
+    RES=(license_command, "+", "c"),
+    persons=(persons_command, "", ""),
+    corpora=(corpora_command, "", ""),
+    lbr_register=(lbr_register_command, "1+", "lc"),
+    lbr_unregister=(lbr_unregister_command, "1+", "lc"),
+    lbr_map=(lbr_map_command, "", ""),
+    help=(usage_command, "", ""),
+)
+
+arg_checker = dict(c=check_corpus_arg, l=check_lbr_id_arg, p=check_person_arg)
+
+
+def check_config(corpus, license):
+    """Reports on possible incompatibilities with frontend config files.
+    Note! This does not cover all possibilities - if something is not
+    found, the problems may well be in this function instead of in the
+    config files."""
+
+    found_containing = []
+    for config in auth_config.KORP_CONFIG:
+        text = codecs.open(config, "r", "utf-8").read()
+        matches = re.findall(
+            r"\bsettings.corpora.%s\s*=\s*[{].*?[{}]" % corpus.lower(),
+            text,
+            flags=re.MULTILINE | re.DOTALL,
+        )
+        if len(matches) > 0:
+            found_containing.append(config)
+
+        if len(matches) > 1:
+            print("! %s: found many in %s" % (corpus, config))
+
+        for match in matches:
+            limitations = re.findall(
+                r"\blimited_access\s*:\s*(\w+)", match, re.MULTILINE | re.DOTALL
+            )
+            if len(limitations) > 1:
+                print("! %s: multiply limited in %s" % (corpus, config))
+
+            if license in ("ACA", "RES") and not limitations:
+                print("! %s: missing limitation in %s" % (corpus, config))
+
+            if license in ("ACA", "RES"):
+                for limitation in limitations:
+                    if limitation == "false":
+                        print(
+                            "! %s: incompatible non-limitation in %s" % (corpus, config)
+                        )
+            else:
+                for limitation in limitations:
+                    if limitation == "true":
+                        print("! %s: incompatible limitation in %s" % (corpus, config))
+
+    if len(found_containing) == 0:
+        print("! %s: not found in any config file" % corpus)
+
+    if len(found_containing) > 1:
+        print(
+            "! %s: found in more than one config file: %s"
+            % (corpus, " ".join(found_containing))
+        )
+
+
+def parse_arglist(args, split_type):
+    """Split list args into a pair of lists according to split_type.
+
+    split_type can be one of the following:
+      '' (or any other False-like): no args used
+      '+': all args to the first list
+      '1+': first arg to the first list, the rest to the second
+      '++': if args contains '--', args before it to the first list,
+            the rest to the second; otherwise like '1+'
+    If a list in the returned pair gets no arguments, its value will
+    be [None].
+    args must have at least len(split_type) items.
+    """
+    if not split_type:
+        return ([None], [None])
+    elif split_type == "+":
+        return (args, [None])
+    elif split_type == "1+":
+        return ([args[0]], args[1:])
+    elif split_type == "++":
+        try:
+            sep_idx = args.index("--")
+            return (args[:sep_idx], args[sep_idx + 1 :])
+        except ValueError:
+            return ([args[0]], args[1:])
+
+
+def do_dispatch(cursor, args):
+    """Dispatch command function based on args, passing cursor.
+
+    args contains the command and its arguments. The arguments are
+    split as the command expects and the command function is called as
+    many times as needed.
+    """
+    if len(args) == 0:
+        raise ArgumentError("No command given")
+    command, args = args[0], args[1:]
+    dispatch_func, dispatch_argsplit, dispatch_argtypes = dispatch.get(
+        command, (None, "", "")
+    )
+    if dispatch_func is None:
+        raise ArgumentError('Unrecognized command "{}"'.format(command))
+    if not dispatch_argsplit:
+        # No arguments needed
+        if args:
+            print(
+                '{}: Warning: Spurious arguments to command "{}"'.format(
+                    sys.argv[0], command
+                )
+            )
+        dispatch_func(cursor, command, ())
+    else:
+        if len(args) < len(dispatch_argsplit):
+            raise ArgumentError(
+                'Command "{}" requires at least {:d} argument{}'.format(
+                    command,
+                    len(dispatch_argsplit),
+                    "s" if len(dispatch_argsplit) > 1 else "",
+                )
+            )
+        parsed_args = parse_arglist(args, dispatch_argsplit)
+        for arg1 in parsed_args[0]:
+            arg1 = arg_checker[dispatch_argtypes[0]](arg1)
+            if arg1 is None:
+                continue
+            for arg2 in parsed_args[1]:
+                # Pass only the non-None arguments, so that they are unpacked
+                # correctly in the command functions
+                if len(dispatch_argtypes) > 1:
+                    arg2 = arg_checker[dispatch_argtypes[1]](arg2)
+                    if arg2 is None:
+                        continue
+                dispatch_args = tuple(arg for arg in [arg1, arg2] if arg)
+                # print(command, dispatch_args)
+                try:
+                    dispatch_func(cursor, command, dispatch_args)
+                except MySQLdb.IntegrityError as e:
+                    # Does this cover all cases?
+                    if "REFERENCES `auth_license`" in str(e):
+                        print(
+                            '{}: Error: License for corpus "{}" has not been'
+                            " specified".format(sys.argv[0], arg2)
+                        )
+
+
+if __name__ == "__main__":
+    conn = MySQLdb.connect(use_unicode=True, **auth_config.DBCONNECT)
+    try:
+        cursor = conn.cursor()
+        do_dispatch(cursor, sys.argv[1:])
+        cursor.close()
+        conn.commit()
+    except ArgumentError as e:
+        print("{}: Error:".format(sys.argv[0]), e)
+        print('Try "{prog} help" for usage'.format(prog=sys.argv[0]))
+    except MySQLdb.MySQLError:
+        import traceback
+
+        # Do not show calls in libraries
+        traceback.print_exc(3)
+        print()
+        print('Try "{prog} help" for usage'.format(prog=sys.argv[0]))

--- a/roles/korp-backend/tasks/main.yml
+++ b/roles/korp-backend/tasks/main.yml
@@ -170,7 +170,7 @@
   notify:
     - restart korp-authserver
 
-- name: Install authing dependencies
+- name: Install korp-authdb.py dependencies
   ansible.builtin.dnf:
     name:
       - python3-mysqlclient

--- a/roles/korp-backend/tasks/main.yml
+++ b/roles/korp-backend/tasks/main.yml
@@ -192,7 +192,7 @@
 - name: Install korp-authdb.py configuration
   ansible.builtin.template:
     src: korp_authdb_config.py.j2
-    dest: /usr/local/bin/korp-authdb/
+    dest: /usr/local/bin/korp-authdb/korp_authdb_config.py
     mode: "0644"
 
 - name: Symlink korp-authdb.py to $PATH

--- a/roles/korp-backend/tasks/main.yml
+++ b/roles/korp-backend/tasks/main.yml
@@ -170,6 +170,32 @@
   notify:
     - restart korp-authserver
 
+- name: Install authing dependencies
+  ansible.builtin.dnf:
+    name:
+      - python3-mysqlclient
+    state: present
+
+- name: Install korp-authdb.py script
+  ansible.builtin.copy:
+    src: korp-authdb.py
+    dest: /usr/local/bin/korp-authdb/
+    mode: "0755"
+
+- name: Install korp-authdb.py configuration
+  ansible.builtin.template:
+    src: korp_authdb_config.py.j2
+    dest: /usr/local/bin/korp-authdb/
+    mode: "0644"
+
+- name: Symlink korp-authdb.py to $PATH
+  ansible.builtin.file:
+    src: /usr/local/bin/korp-authdb/korp-authdb.py
+    dest: /usr/local/bin/korp-authdb.py
+    owner: root
+    group: root
+    state: link
+
 - name: Install latest gevent
   ansible.builtin.pip:
     name: gevent

--- a/roles/korp-backend/tasks/main.yml
+++ b/roles/korp-backend/tasks/main.yml
@@ -183,11 +183,16 @@
     owner: root
     mode: "0755"
 
-- name: Install korp-authdb.py script
+- name: Install korp-authdb.py scripts
   ansible.builtin.copy:
-    src: korp-authdb.py
+    src: "{{ item.filename }}"
     dest: /usr/local/bin/korp-authdb/
-    mode: "0755"
+    mode: "{{ item.mode }}"
+  loop:
+    - filename: "korp-authdb.py"
+      mode: "0755"
+    - filename: "create-new-korp-authdb-DANGER-ERASES-EXISTING.sql"
+      mode: "0644"
 
 - name: Install korp-authdb.py configuration
   ansible.builtin.template:

--- a/roles/korp-backend/tasks/main.yml
+++ b/roles/korp-backend/tasks/main.yml
@@ -176,6 +176,13 @@
       - python3-mysqlclient
     state: present
 
+- name: Set up korp-authdb.py directory
+  ansible.builtin.file:
+    path: /usr/local/bin/korp-authdb/
+    state: directory
+    owner: root
+    mode: "0755"
+
 - name: Install korp-authdb.py script
   ansible.builtin.copy:
     src: korp-authdb.py

--- a/roles/korp-backend/templates/korp_authdb_config.py.j2
+++ b/roles/korp-backend/templates/korp_authdb_config.py.j2
@@ -9,19 +9,19 @@
 
 # MySQL/MariaDB database connection parameters
 DBCONNECT = {
-    host: "{{ korp_db_server }}",
-    port: {{ korp_db_port }},
-    user: 'korp_db_user',
-    passwd: '{{ korp_db_password }}',
-    db: 'korp_auth',
-    charset: 'utf8mb4',
+    "host": "{{ korp_db_server }}",
+    "port": {{korp_db_port}},
+    "user": "{{ korp_db_user }}",
+    "passwd": "{{ korp_db_password }}",
+    "db": "korp_auth",
+    "charset": "utf8mb4",
 }
 
 # For testing whether there is a compatible limited_access setting
 # (and no incompatible limited_access settings) in the frontend.
 KORP_CONFIG = [
-    '/var/www/html/korp/modes/default_mode.js',
-    '/var/www/html/korp/modes/parallel_mode.js',
-    '/var/www/html/korp/modes/swedish_mode.js',
-    '/var/www/html/korp/modes/other_languages_mode.js',
-}
+    "/var/www/html/korp/modes/default_mode.js",
+    "/var/www/html/korp/modes/parallel_mode.js",
+    "/var/www/html/korp/modes/swedish_mode.js",
+    "/var/www/html/korp/modes/other_languages_mode.js",
+]

--- a/roles/korp-backend/templates/korp_authdb_config.py.j2
+++ b/roles/korp-backend/templates/korp_authdb_config.py.j2
@@ -11,8 +11,8 @@
 DBCONNECT = {
     "host": "{{ korp_db_server }}",
     "port": {{korp_db_port}},
-    "user": "{{ korp_db_user }}",
-    "passwd": "{{ korp_db_password }}",
+    "user": "korp_admin",
+    "passwd": "{{ lookup('passwordstore', 'lb_passwords/korp/korp_db_admin_password') }}",
     "db": "korp_auth",
     "charset": "utf8mb4",
 }

--- a/roles/korp-backend/templates/korp_authdb_config.py.j2
+++ b/roles/korp-backend/templates/korp_authdb_config.py.j2
@@ -1,0 +1,27 @@
+# -*- mode: Python; -*-
+
+# auth_config.py.template
+#
+# Configuration file template for the authing/auth script
+#
+# Copy to auth_config.py and edit the values as appropriate.
+
+
+# MySQL/MariaDB database connection parameters
+DBCONNECT = {
+    host: "{{ korp_db_server }}",
+    port: {{ korp_db_port }},
+    user: 'korp_db_user',
+    passwd: '{{ korp_db_password }}',
+    db: 'korp_auth',
+    charset: 'utf8mb4',
+}
+
+# For testing whether there is a compatible limited_access setting
+# (and no incompatible limited_access settings) in the frontend.
+KORP_CONFIG = [
+    '/var/www/html/korp/modes/default_mode.js',
+    '/var/www/html/korp/modes/parallel_mode.js',
+    '/var/www/html/korp/modes/swedish_mode.js',
+    '/var/www/html/korp/modes/other_languages_mode.js',
+}


### PR DESCRIPTION
This script used to be manually installed, now we're versioning it.

Differences from the previous version:

- Different name (auth -> korp-authdb.py)
- Switch from Python2 to Python3, requiring a few small changes
- Make it executable from $PATH
- `mysql-client` Python library automatically installed on Korp server