### PR TITLE
KP-9048 Create media directory and symlink it to /var/www

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -28,6 +28,7 @@ korp_frontend_annlab_dir: "{{ korp_static_frontend_cgi_dir }}/annlab"
 korp_backend_cgibin_dir: "{{ korp_static_frontend_cgi_dir }}/korp"
 korp_backend_download_cgi: "{{ korp_url }}/cgi-bin/korp/korp_download.cgi"
 
+media_dir: "/data2/media"
 
 # WP-Cli specific
 remote_deploy_user: 'apache'

--- a/roles/korp-frontend/tasks/main.yml
+++ b/roles/korp-frontend/tasks/main.yml
@@ -134,3 +134,16 @@
   with_items:
     - {src: "{{ korp_static_frontend_cgi_dir }}", dest: "{{ korp_frontend_www_home }}/cgi-bin"}
     - {src: "{{ korp_frontend_annlab_dir }}/deptrees", dest: "{{ korp_frontend_www_home }}/lib/annlab_deptrees"}
+
+- name: Create media directory
+  file:
+    path: "{{ media_dir }}"
+    owner: root
+    mode: '0733'
+    state: directory
+
+- name: Symlink media directory to /var/www/html
+  file:
+    src: "{{ media_dir }}"
+    dest: "/var/www/html/media"
+    state: link


### PR DESCRIPTION
Korp serves some static media files (e.g. the reittidemo video and audio files for the gospel parallel corpora) which we want to store on a larger disk and serve to the internet. Previously this directory and symlink have been created manually, but now this is automated.