### PR TITLE
KP-9088 Ensure base dirs before symlink creation

### DIFF
--- a/roles/korp-backend/defaults/main.yml
+++ b/roles/korp-backend/defaults/main.yml
@@ -25,12 +25,22 @@ korp_db_user: "korp"
 korp_db_password: "{{ lookup('passwordstore', 'lb_passwords/korp/korp_db_user_password') }}"
 backend_cache_dir: "/data1/korp/cache"
 
-mk_directories:
+mk_base_directories:
+  - {path: /data1/, owner: root, group: root, mode: "u+rwx,g+rxs,o+rx"}
+  - {path: /data2/, owner: root, group: root, mode: "u+rwx,g+rx,o+rx"}
   - {path: /v/, owner: root, group: root, mode: "u+rwx,g+rwxs,o+rx"}
+  - {path: /data1/cwbdata/corpora, owner: root, group: clarin, mode: "u+rwx,g+rwxs,o+rx"}
+  - {path: /data1/korp/, owner: root, group: root, mode: "u+rwx,g+rwxs,o+rx"}
+
+v_to_data1_symlinks:
+  - {src: /data1/korp, dest: /v/korp}
+  - {src: /data1/cwbdata/corpora, dest: /v/corpora}
+
+mk_additional_directories:
+  - {path: /data1/cwbdata/korp, owner: root, group: clarin, mode: "u+rwx,g+rwxs,o+rx"}
   - {path: /v/appl/, owner: root, group: root, mode: "u+rwx,g+rwxs,o+rx"}
   - {path: /v/corpora/data, owner: root, group: clarin, mode: "u+rwx,g+rwxs,o+rx"}
   - {path: "{{ cwb_registry }}", owner: root, group: clarin, mode: "u+rwx,g+rwxs,o+rx"}
-  - {path: /data1/korp/, owner: root, group: root, mode: "u+rwx,g+rwxs,o+rx"}
   - {path: /data1/korp/log/, owner: root, group: root, mode: "u+rwx,g+rwxs,o+rwx"}
   - {path: /data1/korp/log/korp-py, owner: gunicorn, group: root, mode: "u+rwx,g+rwxs,o+rwx"}
   - {path: "{{ backend_cache_dir }}", owner: gunicorn, group: apache, mode: "u+rwx,g+rwxs,o-rwx"}

--- a/roles/korp-backend/tasks/main.yml
+++ b/roles/korp-backend/tasks/main.yml
@@ -45,27 +45,32 @@
       - mariadb-devel
       - python-xlwt # for korp_download.cgi
 
-- name: Create directories
+- name: Create base directories
   ansible.builtin.file:
     path: "{{ item.path }}"
-    state: directory
-    mode: "{{ item.mode }}"
+    state: "{{ item.state }}"
+    mode: directory
     owner: "{{ item.owner }}"
     group: "{{ item.group }}"
-  loop: "{{ mk_directories }}"
+  loop: "{{ mk_base_directories }}"
 
 - name: symlink /v subdirs to /data1
   ansible.builtin.file:
-    src: "/data1/{{ item.src }}"
-    dest: "/v/{{ item.dest }}"
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
     owner: root
     group: root
     state: link
-  loop:
-    - src: korp
-      dest: korp
-    - src: cwbdata/corpora
-      dest: corpora
+  loop: "{{ v_to_data1_symlinks }}"
+
+- name: Create additional directories
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: "{{ item.state }}"
+    mode: directory
+    owner: "{{ item.owner }}"
+    group: "{{ item.group }}"
+  loop: "{{ mk_additional_directories }}"
 
 - name: Clone backend
   ansible.builtin.git:


### PR DESCRIPTION
This is related to getting the states of VMWare production machines, with /data1 and /data2, to be compatible with Pouta testing machines. On production machines, /data1 and /data2 are large partitions for lots of data, and /v/ contains a few symlinks into them. We also want to create subdirectories under the /v/ symlinks. To support all this consistently, we first ensure the base directories are there, then make the desired symlinks, then create more directories under the symlinks.