### PR TITLE
KP-9088 Update version number

### DIFF
--- a/roles/korp-frontend/tasks/main.yml
+++ b/roles/korp-frontend/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: Add nodejs repository
   ansible.builtin.shell:
     cmd: curl -sL https://rpm.nodesource.com/setup_12.x | bash -
-    creates: /etc/yum.repos.d/nodesource-el7.repo
+    creates: /etc/yum.repos.d/nodesource-el9.repo
 
 - name: Install basics
   ansible.builtin.dnf:


### PR DESCRIPTION
This slow task was always being run because the random bash script we fetch from the Internet and run now creates a directory with a different name. This updates the expected name.