### PR TITLE
KP-9173 Add a configuration file for local MariaDB installations

### DIFF
--- a/roles/create_database/files/mariadb-settings.sql
+++ b/roles/create_database/files/mariadb-settings.sql
@@ -1,0 +1,2 @@
+SET character_set_server = 'utf8mb4';
+SET collation_server = 'utf8mb4_general_ci';

--- a/roles/create_database/tasks/main.yml
+++ b/roles/create_database/tasks/main.yml
@@ -9,6 +9,12 @@
     state: present
   become: true
 
+- name: Install MariaDB configuration
+  ansible.builtin.copy:
+    src: "korp_charset.cnf"
+    dest: "/etc/my.cnf.d/"
+  become: true
+
 - name: Start MariaDB service
   ansible.builtin.systemd_service:
     name: mariadb


### PR DESCRIPTION
This configuration is needed because current versions of MariaDB default to a latin1-based charset, we want to enforce utf8.