### PR TITLE
KP-9391 Set backup error mail recipient to root@localhost

### DIFF
--- a/roles/fetch_backup/templates/get_pouta_webserver_vm_backup.j2
+++ b/roles/fetch_backup/templates/get_pouta_webserver_vm_backup.j2
@@ -73,7 +73,7 @@ fi # ! [ -d $LOCAL_BACKUP_DIR/ ]
 # $1: Error message
 # $2: Path to file
 mail_log() {
-RECIPIENT=root # Use .forward to forward root's mail if needed.
+RECIPIENT=root@localhost # Use .forward to forward root's mail if needed.
    if [ -n $2 ]; then # mail the file content
        cat $2 | mail -s "$0 @ `hostname -f`: $1" $RECIPIENT
    else

--- a/roles/fetch_backup/templates/get_signbank_backup.j2
+++ b/roles/fetch_backup/templates/get_signbank_backup.j2
@@ -30,7 +30,7 @@ fi # ! [ -d $BACKUP_DIR/ ]
 # $1: Error message
 # $2: Path to file
 mail_log() {
-RECIPIENT=root # Use .forward to forward root's mail if needed.
+RECIPIENT=root@localhost # Use .forward to forward root's mail if needed.
    if [ -n $2 ]; then # mail the file content
        cat $2 | mail -s "$0 @ `hostname -f`: $1" $RECIPIENT
    else


### PR DESCRIPTION
According to Martin's investigations (see ticket comments for details), messages sent to `root` will not end up in ling-admin@csc.fi, while mails sent to `root@localhost` will. Changed the recipients of the mailed logs accordingly.