### PR TITLE
KP-9468 production mail

### DIFF
--- a/production-preprocess.yml
+++ b/production-preprocess.yml
@@ -23,3 +23,10 @@
         validate: postfix check
       become: true
       tags: postfix-vmware-configuration
+      notify: Reload postfix
+
+  handlers:
+    - name: Reload postfix
+      ansible.builtin.service:
+        name: postfix.service
+        state: reloaded

--- a/production-preprocess.yml
+++ b/production-preprocess.yml
@@ -14,3 +14,12 @@
     - name: Restart server if needed
       reboot:
       when: sestatus.changed|default(false)
+
+    - name: Fix sent mail origin to korp.csc.fi
+      ansible.builtin.lineinfile:
+        path: /etc/postfix/main.cf
+        regexp: "^myorigin = "
+        line: "myorigin = $myhostname"
+        validate: postfix check
+      become: true
+      tags: postfix-vmware-configuration


### PR DESCRIPTION
Fix the mail sending configuration here, because we aren't using the Pouta-specific setup in ansible-common, nor do we want to. Due to manual fixes made to production, running the newly added task would cause no changes:
```
(.venv) vagrant@kpdev:~/scratch/korp-ansible$ ansible-playbook -vi inventories/korp-prod korp-production.yml -t postfix-vmware-configuration --check --diff --extra-vars ansible_user=ajarven
Using /home/vagrant/scratch/korp-ansible/ansible.cfg as config file

PLAY [Production-only provisioning steps for Korp] ********************************************************************************

TASK [Gathering Facts] ************************************************************************************************************
ok: [korp]

TASK [Fix sent mail origin to korp.csc.fi] ****************************************************************************************
ok: [korp] => {"backup": "", "changed": false, "msg": ""}

PLAY [Set up Korp and its requirements] *******************************************************************************************

TASK [Gathering Facts] ************************************************************************************************************
ok: [korp]

PLAY [Production-only provisioning steps for Korp] ********************************************************************************

TASK [Gathering Facts] ************************************************************************************************************
ok: [korp]

PLAY RECAP ************************************************************************************************************************
korp                       : ok=4    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```