### PR TITLE
WIP KP-6954 Add nftables handling for non-vmware hosts

### DIFF
--- a/inventories/korp-dev
+++ b/inventories/korp-dev
@@ -8,6 +8,7 @@ all:
     korp:
       ansible_host: 195.148.21.64
       ansible_user: almalinux
+      is_vmware: no
       allowed_ips:
         - 192.168.1
         - 127.0.0.1

--- a/inventories/korp-prod
+++ b/inventories/korp-prod
@@ -2,3 +2,4 @@ all:
   hosts:
     korp:
       ansible_host: korp3.csc.fi
+      is_vmware: yes

--- a/roles/firewall/files/nftables.conf
+++ b/roles/firewall/files/nftables.conf
@@ -1,0 +1,17 @@
+add table ip filter
+add chain ip filter INPUT { type filter hook input priority 0; policy drop; }
+add chain ip filter FORWARD { type filter hook forward priority 0; policy drop; }
+add chain ip filter OUTPUT { type filter hook output priority 0; policy accept; }
+
+add set ip filter ssh_allowed { type ipv4_addr; flags interval; }
+add element ip filter ssh_allowed { 193.166.1.0/24,193.166.2.0/24,193.166.84.0/24,193.166.85.0/24,193.166.83.192/28 }
+
+add rule ip filter INPUT ip saddr @ssh_allowed tcp dport 22 counter accept comment "Allow SSH"
+add rule ip filter INPUT tcp dport 80 counter accept comment "Allow http from everywhere"
+add rule ip filter INPUT tcp dport 443 counter accept comment "Allow https from everywhere"
+
+add rule ip filter INPUT ct state related,established  counter accept
+add rule ip filter INPUT ip protocol icmp counter accept
+add rule ip filter INPUT iifname "lo" counter accept
+add rule ip filter INPUT counter reject with icmp type host-prohibited
+add rule ip filter FORWARD counter reject with icmp type host-prohibited

--- a/roles/firewall/handlers/main.yml
+++ b/roles/firewall/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: restart nftables
+  command: systemctl restart nftables

--- a/roles/firewall/tasks/main.yml
+++ b/roles/firewall/tasks/main.yml
@@ -1,47 +1,12 @@
 ---
 # Set firewall in CSC compatible way
 
-- name: Install iptables
-  ansible.builtin.dnf:
-    name:
-      - iptables-legacy
+- name: Include Pouta iptables configuration
+  when: not is_vmware
+  include_tasks:
+    file: pouta.yml
 
-- name: test for PATA VM
-  stat: path=/etc/csc/host.info
-  register: pata_host
-
-- name: copy IP4/6 firewall statup scripts (if not already present)
-  template:
-    src: firewall.j2
-    dest: "/etc/rc.d/rc{{ item }}.firewall"
-    mode: 0750
-    force: false
-  with_items:
-    - ""
-    - 6
-
-- name: copy IP4/6 local settings
-  template:
-    src: firewall.local.j2
-    dest: "/etc/rc.d/rc{{ item }}.firewall.local"
-    mode: 0750
-  with_items:
-    - ""
-    - 6
-
-- name: update rc.local
-  lineinfile:
-    dest: /etc/rc.d/rc.local
-    line: "sleep 1m ; /bin/sh /etc/rc.d/rc.firewall; /bin/sh /etc/rc.d/rc6.firewall"
-    regexp: "^sleep 1m"
-    owner: root
-    state: present
-    insertafter: EOF
-    create: true
-  when: pata_host.stat.exists == False
-
-- name: execute firewall
-  command: /etc/rc.d/{{ item }} restart
-  with_items:
-    - rc.firewall
-    - rc6.firewall
+- name: Include VMWare iptables configuration
+  when: is_vmware
+  include_tasks:
+    file: vmware.yml

--- a/roles/firewall/tasks/pouta.yml
+++ b/roles/firewall/tasks/pouta.yml
@@ -1,0 +1,15 @@
+---
+
+- name: Install nftables
+  ansible.builtin.dnf:
+    name:
+      - nftables
+
+- name: Install nftables config (RHEL-based)
+  ansible.builtin.copy:
+    src: nftables.conf
+    dest: /etc/sysconfig/nftables.conf
+    owner: root
+    group: root
+    mode: "0640"
+  notify: restart nftables

--- a/roles/firewall/tasks/vmware.yml
+++ b/roles/firewall/tasks/vmware.yml
@@ -1,0 +1,41 @@
+---
+
+- name: test for PATA VM
+  stat: path=/etc/csc/host.info
+  register: pata_host
+
+- name: copy IP4/6 firewall statup scripts (if not already present)
+  template:
+    src: firewall.j2
+    dest: "/etc/rc.d/rc{{ item }}.firewall"
+    mode: 0750
+    force: false
+  with_items:
+    - ""
+    - 6
+
+- name: copy IP4/6 local settings
+  template:
+    src: firewall.local.j2
+    dest: "/etc/rc.d/rc{{ item }}.firewall.local"
+    mode: 0750
+  with_items:
+    - ""
+    - 6
+
+- name: update rc.local
+  lineinfile:
+    dest: /etc/rc.d/rc.local
+    line: "sleep 1m ; /bin/sh /etc/rc.d/rc.firewall; /bin/sh /etc/rc.d/rc6.firewall"
+    regexp: "^sleep 1m"
+    owner: root
+    state: present
+    insertafter: EOF
+    create: true
+  when: pata_host.stat.exists == False
+
+- name: execute firewall
+  command: /etc/rc.d/{{ item }} restart
+  with_items:
+    - rc.firewall
+    - rc6.firewall


### PR DESCRIPTION
This is an attempt to parametrize in the inventories whether we are on a VMWare host, in case we try to stick to their funky processes, or if we're on some other (RH-based) host, in which case we use "normal" nftables rules literally.

firewalld is another option, but it would be even more different from the VMWare stuff.