### PR TITLE
KP-10158 Proposed fixes to cfinsl dl description texts

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -295,11 +295,14 @@ autoindex_info:
 
   - regex: 'cfinsl/cfinsl'
     text: 'Corpus of Finnish Sign Language'
-    url: 'http://urn.fi/urn:nbn:fi:lb-2019012321'
+    url: 'http://urn.fi/urn:nbn:fi:lb-2024060525'
 
   - regex: 'cfinsl/cfsts'
     text: 'Corpus of Finland-Swedish Sign Language'
     url: 'http://urn.fi/urn:nbn:fi:lb-2024090327'
+
+  - regex: 'cfinsl/*.pdf'
+    text: 'Signer metadata'
 
   - regex: 'cfinsl'
     text: 'Sign Language Corpora (in Finland)'

--- a/group_vars/all
+++ b/group_vars/all
@@ -293,6 +293,12 @@ autoindex_info:
     text: 'CFSTS Conversations'
     url: 'https://urn.fi/urn:nbn:fi:lb-2024090321'
 
+  - regex: 'cfinsl/cfinsl/*.pdf'
+    text: 'Signer metadata'
+
+  - regex: 'cfinsl/cfinsl/*.pdf'
+    text: 'Signer metadata'
+
   - regex: 'cfinsl/cfinsl'
     text: 'Corpus of Finnish Sign Language'
     url: 'http://urn.fi/urn:nbn:fi:lb-2024060525'
@@ -300,9 +306,6 @@ autoindex_info:
   - regex: 'cfinsl/cfsts'
     text: 'Corpus of Finland-Swedish Sign Language'
     url: 'http://urn.fi/urn:nbn:fi:lb-2024090327'
-
-  - regex: 'cfinsl/*.pdf'
-    text: 'Signer metadata'
 
   - regex: 'cfinsl'
     text: 'Sign Language Corpora (in Finland)'


### PR DESCRIPTION
The Corpus of Finnish Sign Language description link pointed to a metadata entry, this has now been replaced with a link to the portal group page.

The newly added PDFs in cfinsl and cfsts had generic default descriptions based on the directory they were in, this is my proposed description text ("Signer metadata").