### PR TITLE
KP-10169 Run an hourly script that kills zombified gunicorn tasks

### DIFF
--- a/roles/korp-backend/defaults/main.yml
+++ b/roles/korp-backend/defaults/main.yml
@@ -13,8 +13,10 @@ korp_backend_home: "{{ korp_git_root }}/{{ korp_backend_name }}"
 korp_backend_auth_home: "{{ korp_git_root }}/Kielipankki-korp-backend-auth"
 korp_backend_plugin_home: "{{ korp_git_root }}/Kielipankki-korp-backend-plugins"
 kp_util_scripts_home: "{{ korp_utils_root }}/{{ kp_utils_name }}"
-
 korp_backend_venv: "{{ korp_git_root }}/{{ korp_backend_name }}/venv"
+gunicorn_worker_max_mem_gb: 20
+zombie_hunter_logfile: /var/log/korp/zombie_hunter.log
+
 timezone: "Europe/Helsinki"
 
 korp_db_name: "korp"

--- a/roles/korp-backend/tasks/main.yml
+++ b/roles/korp-backend/tasks/main.yml
@@ -244,6 +244,16 @@
   loop:
     - clear_korp_cache
 
+- name: Install hourly crontab scripts
+  ansible.builtin.template:
+    src: "{{ item }}"
+    dest: "/etc/cron.hourly/"
+    owner: root
+    group: root
+    mode: "0755"
+  loop:
+    - zombie_hunter.sh
+
 - name: Install old API / korp_download.cgi
   when: not future_build
   ansible.builtin.copy:

--- a/roles/korp-backend/templates/zombie_hunter.sh
+++ b/roles/korp-backend/templates/zombie_hunter.sh
@@ -6,7 +6,7 @@ MEMORY_LIMIT_KB=$((MEMORY_LIMIT_GB * 1024 * 1024))
 ps -eo pid,comm,rss --no-headers | grep gunicorn | while read pid comm rss; do
     if [ "$rss" -gt "$MEMORY_LIMIT_KB" ]; then
         gib=$(awk "BEGIN {printf \"%.2f\", $rss/1048576}")
-        echo $(date)": Killing gunicorn process $pid using ${gib}GB of memory" >> {{zombie_hunter_logfile }}
+        echo $(date)": Killing gunicorn process $pid using ${gib}GB of memory" >> {{ zombie_hunter_logfile }}
         kill -TERM "$pid"
         sleep 1
         # If TERM doesn't work, use KILL after a delay

--- a/roles/korp-backend/templates/zombie_hunter.sh
+++ b/roles/korp-backend/templates/zombie_hunter.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+MEMORY_LIMIT_GB={{ gunicorn_worker_max_mem_gb }}
+MEMORY_LIMIT_KB=$((MEMORY_LIMIT_GB * 1024 * 1024))
+
+ps -eo pid,comm,rss --no-headers | grep gunicorn | while read pid comm rss; do
+    if [ "$rss" -gt "$MEMORY_LIMIT_KB" ]; then
+        gib=$(awk "BEGIN {printf \"%.2f\", $rss/1048576}")
+        echo $(date)": Killing gunicorn process $pid using ${gib}GB of memory" >> {{zombie_hunter_logfile }}
+        kill -TERM "$pid"
+        sleep 1
+        # If TERM doesn't work, use KILL after a delay
+        if kill -0 "$pid" 2>/dev/null; then
+            sleep 5 && kill -KILL "$pid" 2>/dev/null &
+            echo $(date)":  gunicorn process $pid was unresponsive, had to kill -9" >> {{ zombie_hunter_logfile }}
+        fi
+    fi
+done


### PR DESCRIPTION
Zombified here means taking > 20G ram, which usually means that they have been running for abnormally long too.