### PR TITLE
KP-9934 Add cache-clearing to korp-backend restarts

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -25,11 +25,6 @@ kp_utils_name: Kielipankki-utilities
 
 korp_shib_spoof_key: "{{ lookup('passwordstore', 'lb_passwords/korp-dev/wp_shib_spoof_key') }}"
 
-korp_domain: https://www.kielipankki.fi
-korp_path: "korp"
-korp_url: "{{ korp_domain }}/{{ korp_path }}"
-korp_backend_url: "{{ korp_url }}/api8/"
-
 # static hacks for download_cgi
 korp_static_frontend_cgi_dir: "/data1/korp/frontend_static/cgi-bin"
 korp_backend_cgibin_dir: "{{ korp_static_frontend_cgi_dir }}/korp"

--- a/inventories/dev/host_vars/korp.yml
+++ b/inventories/dev/host_vars/korp.yml
@@ -1,7 +1,4 @@
----
-
-future_build: True
 korp_domain: https://www.kielipankki.fi
-korp_path: "future/korp"
+korp_path: "staging/korp"
 korp_url: "{{ korp_domain }}/{{ korp_path }}"
 korp_backend_url: "{{ korp_url }}/api8"

--- a/inventories/prod/host_vars/korp.yml
+++ b/inventories/prod/host_vars/korp.yml
@@ -1,7 +1,4 @@
----
-
-future_build: True
 korp_domain: https://www.kielipankki.fi
-korp_path: "future/korp"
+korp_path: "korp"
 korp_url: "{{ korp_domain }}/{{ korp_path }}"
 korp_backend_url: "{{ korp_url }}/api8"

--- a/roles/korp-backend/templates/korp-backend.service
+++ b/roles/korp-backend/templates/korp-backend.service
@@ -5,8 +5,6 @@ After=network.target
 
 [Service]
 Type=notify
-# .
-# the specific user that our service will run as
 User=gunicorn
 Group=gunicorn
 # another option for an even more restricted service is
@@ -14,7 +12,17 @@ Group=gunicorn
 # see http://0pointer.net/blog/dynamic-users-with-systemd.html
 RuntimeDirectory=gunicorn
 WorkingDirectory={{ korp_backend_home }}
+
+# MAIN PART
+# --worker-class gevent:    see https://docs.gunicorn.org/en/stable/settings.html#worker-class
+# --max-requests 500:       intended as a mitigation strategy against resource leaks, recycle workers after 500 requests
+# --limit-request-line 0:   unlimited size HTTP requests (we might get very long requests)
 ExecStart={{ korp_backend_home }}/venv/bin/gunicorn --worker-class gevent --timeout 120 --workers 2 --max-requests 500 --limit-request-line 0 {{ 'run:create_app()' if future_build|bool else 'korp:app' }}
+
+# CACHE CLEARING
+# After restarts, try to clear the cache via the API. On failure, silently retry a couple of times.
+ExecStartPost=/bin/bash -c 'for i in {1..3}; do /usr/bin/curl -f --connect-timeout 5 --max-time 10 {{ korp_backend_url }}/cache && break || sleep 2; done'
+
 ExecReload=/bin/kill -s HUP $MAINPID
 KillMode=mixed
 TimeoutStopSec=5

--- a/roles/korp-frontend/tasks/future-korp-frontend-code.yaml
+++ b/roles/korp-frontend/tasks/future-korp-frontend-code.yaml
@@ -35,7 +35,7 @@
   ansible.builtin.replace:
     path: "{{ korp_frontend_config_home }}/app/config.yml"
     regexp: "korp_backend_url: .*"
-    replace: "korp_backend_url: {{ korp_backend_url }}"
+    replace: "korp_backend_url: {{ korp_backend_url }}/"
 
 # Copied from kielipankki-korp-frontend-code.yaml
 - name: Skip this if all up to date


### PR DESCRIPTION
This also required setting the backend address per host, so that configuration is now moved from group_vars/all to eg. inventories/prod/host_vars/korp.yml.