### PR TITLE
KP-10430 `korp_download`: Use `query_params` also with `query_result`

### DIFF
--- a/roles/korp-backend/files/korp_download/korpexport/exporter.py
+++ b/roles/korp-backend/files/korp_download/korpexport/exporter.py
@@ -318,36 +318,36 @@ class KorpExporter(object):
         Set a private attribute to contain the result, a dictionary
         converted from the JSON returned by Korp.
         """
+        if query_params:
+            self._query_params = query_params
+        elif "query_params" in self._form:
+            self._query_params = json.loads(self._form.get("query_params"))
+        else:
+            self._query_params = self._form
+        self._rename_query_params()
+        self._decode_query_params()
+        if "debug" in self._form and "debug" not in self._query_params:
+            self._query_params["debug"] = self._form["debug"]
+        # If the format uses structural information, add the
+        # structs in param "show_struct" to "show", so that tokens
+        # are associated with information on opening and closing
+        # those structures. Param "show_struct" only gives us
+        # struct attribute values for a whole sentence.
+        if (self._formatter.structured_format
+            and self._query_params.get("show_struct")):
+            if self._query_params.get("show"):
+                self._query_params["show"] += (
+                    "," + self._query_params["show_struct"])
+            else:
+                self._query_params["show"] = self._query_params["show_struct"]
+        logging.debug("query_params: %s", self._query_params)
         if "query_result" in self._form:
             query_result_json = self._form.get("query_result", "{}")
         else:
-            if query_params:
-                self._query_params = query_params
-            elif "query_params" in self._form:
-                self._query_params = json.loads(self._form.get("query_params"))
-            else:
-                self._query_params = self._form
-            self._rename_query_params()
-            self._decode_query_params()
-            if "debug" in self._form and "debug" not in self._query_params:
-                self._query_params["debug"] = self._form["debug"]
-            # If the format uses structural information, add the
-            # structs in param "show_struct" to "show", so that tokens
-            # are associated with information on opening and closing
-            # those structures. Param "show_struct" only gives us
-            # struct attribute values for a whole sentence.
-            if (self._formatter.structured_format
-                and self._query_params.get("show_struct")):
-                if self._query_params.get("show"):
-                    self._query_params["show"] += (
-                        "," + self._query_params["show_struct"])
-                else:
-                    self._query_params["show"] = self._query_params["show_struct"]
-            logging.debug("query_params: %s", self._query_params)
             query_result_json = self._query_korp_server(korp_server_url)
-            # Support "sort" in format params even if not specified
-            if "sort" not in self._query_params:
-                self._query_params["sort"] = "none"
+        # Support "sort" in format params even if not specified
+        if "sort" not in self._query_params:
+            self._query_params["sort"] = "none"
         self._query_result = json.loads(query_result_json)
         logging.debug("query result: %s", self._query_result)
         if "ERROR" in self._query_result or "kwic" not in self._query_result:


### PR DESCRIPTION
Fix `korp_download.cgi` (module `korpexport.exporter`) to take query parameters (URL parameter `query_params`) into account even when also passing the query result (`query_result`), as the query parameters can be referred to in the file content and file name. As before, if `query_result` is passed, it is used as the main file content and the query is _not_ re-performed.

This fix is required for KWIC downloading to produce the same results when the Korp frontend passes the query result to the KWIC download script as when it passes only the query parameters. Passing the query result often makes downloading faster and sometimes even makes it happen by avoiding a server-side timeout. Previously, the Korp frontend never passed the query result and the download script always re-performed the query, so this bug or omission did not surface.

On the code level, the change is smaller than the diff would indicate: moving an `if` branch to inside the previous `else` branch, which is now always executed and thus dedented (and shows up in the diff unless you ignore white-space changes).

This change has been tested locally.