### PR TITLE
KP-10338 Make lilabi conf match the spec

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -796,7 +796,7 @@ autoindex_info:
     text: 'Finnish Magazines and Newspapers from the 1990s and 2000s (VRT) v2'
     url: 'http://urn.fi/urn:nbn:fi:lb-201908191'
 
-  - regex: 'lilabi/*.zip'
+  - regex: 'lilabi/lilabi-src'
     text: 'CC-BY-NC'
     url: 'http://urn.fi/urn:nbn:fi:lb-2025060802'
 


### PR DESCRIPTION
This was tweaked back and forth, but now it works as our documentation specifies and how it works for e.g. ylenews-fi-2011-2018-selko-src. The mistake was trying to show the "zip" file extension in the file list: that caused the html file to be downloaded as a "zip file" instead of displaying it in the browser.