### PR TITLE
Fix Korp backend future configuration: `CWB_SCAN_EXECUTABLE`

### DIFF
--- a/roles/korp-backend/templates/future/config.py.j2
+++ b/roles/korp-backend/templates/future/config.py.j2
@@ -10,7 +10,7 @@ WSGI_PORT = 1234
 
 # The absolute path to the CQP binaries
 CQP_EXECUTABLE = "/usr/local/bin/cqp"
-CWB_SCAN_EXECUTABLE = "/usr/local/bin/cqp-scan-corpus"
+CWB_SCAN_EXECUTABLE = "/usr/local/bin/cwb-scan-corpus"
 
 # The absolute path to the CWB registry files
 CWB_REGISTRY = "/v/corpora/registry"


### PR DESCRIPTION
Fix the value of `CWB_SCAN_EXECUTABLE` in the Korp backend future configuration to `/usr/local/bin/cwb-scan-corpus` instead of the non-existent `/usr/local/bin/cqp-scan-corpus`.

The reference to a non-existent executable caused the Korp frontend display the following error [when searching for any word and trying to get statistics](https://www.kielipankki.fi/future/korp/#?search_tab=1&search=cqp&corpus=kotus_sp&result_tab=2):

> KorpBackendError: CQPError: [Errno 2] No such file or directory: '/usr/local/bin/cqp-scan-corpus'

I haven’t tested the fix as I don’t know how to do that easily, but I think it should make the above case work.

(I didn’t create a Jira issue for this two-letter fix. If you wish to do that and add the Jira issue number to the commit message, branch name and PR title, feel free to do it.)