### PR TITLE
KP-11676 Add explicit localhost to inventory

### DIFF
--- a/inventories/prod/hosts
+++ b/inventories/prod/hosts
@@ -4,3 +4,5 @@ all:
       ansible_host: korp3.csc.fi
       korp_db_server: kielipankkidb9.csc.fi
       db_root_password: "{{ lookup('passwordstore', 'lb_passwords/korp/korp_db_admin_password') }}"
+    localhost:
+      ansible_connection: local


### PR DESCRIPTION
This is needed: if Ansible uses implicit localhost, the `inventory_file` variable is not set and can't be accessed when logging to Koivu.

Without it, we got errors like
```
TASK [kielipankki.common.playbook_wrappers : Build run start info dict] ***********************************************************
fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable.. 'inventory_file' is undefined\n\nThe error appears to be in '/home/vagrant/.ansible/collections/ansible_collections/kielipankki/common/roles/playbook_wrappers/tasks/pre-run-steps.yml': line 63, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Build run start info dict\n  ^ here\n"}
```